### PR TITLE
Added @ExpectedDatabase(strict=true/false) option.

### DIFF
--- a/src/main/java/org/springframework/test/dbunit/DbUnitRunner.java
+++ b/src/main/java/org/springframework/test/dbunit/DbUnitRunner.java
@@ -24,7 +24,6 @@ import java.util.Map;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.dbunit.Assertion;
 import org.dbunit.database.IDatabaseConnection;
 import org.dbunit.dataset.IDataSet;
 import org.springframework.core.annotation.AnnotationUtils;
@@ -32,8 +31,9 @@ import org.springframework.test.dbunit.annotation.DatabaseOperation;
 import org.springframework.test.dbunit.annotation.DatabaseSetup;
 import org.springframework.test.dbunit.annotation.DatabaseTearDown;
 import org.springframework.test.dbunit.annotation.ExpectedDatabase;
+import org.springframework.test.dbunit.assertion.DatabaseAssertion;
+import org.springframework.test.dbunit.assertion.DatabaseAssertionFactory;
 import org.springframework.test.dbunit.dataset.DataSetLoader;
-import org.springframework.test.dbunit.helper.AssertionHelper;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -124,11 +124,8 @@ class DbUnitRunner {
 					logger.debug("Veriftying @DatabaseTest expectation using " + annotation.value());
 				}
 				
-				if ( annotation.strict() ) {
-					Assertion.assertEquals(expectedDataSet, actualDataSet);
-				} else {
-					AssertionHelper.assertEqualsNonStrict(expectedDataSet, actualDataSet);
-				}
+				DatabaseAssertion assertion = DatabaseAssertionFactory.createDatabaseAssertion(annotation.assertionMode());
+				assertion.assertEquals(expectedDataSet, actualDataSet);
 			}
 		}
 	}

--- a/src/main/java/org/springframework/test/dbunit/annotation/DatabaseAssertionMode.java
+++ b/src/main/java/org/springframework/test/dbunit/annotation/DatabaseAssertionMode.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2010 the original author or authors
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.test.dbunit.annotation;
+
+
+/**
+ * Database assertion modes which determine {@link ExpectedDatabase} behavior.
+ * 
+ * @author Mario Zagar
+ *
+ */
+public enum DatabaseAssertionMode {
+
+	/**
+	 * Will use default DbUnit data sets assertions.
+	 */
+	DEFAULT,
+	
+	/**
+	 * Allows specifying only specific columns and tables in expected data set.
+	 * Unspecified tables and columns are ignored.
+	 * </p>
+	 * <strong>Notes:</strong> 
+	 * <li>Expected row order must match order in actual data set.</li>
+	 * <li>Specified columns must match in all rows, e.g. specifying 'column1' value without 'column2' value in one 
+	 * row and only 'column2' value in another is not allowed - both 'column1' and 'column2' values must be specified
+	 * in all rows.</li>
+	 * 
+	 */
+	NON_STRICT
+}

--- a/src/main/java/org/springframework/test/dbunit/annotation/ExpectedDatabase.java
+++ b/src/main/java/org/springframework/test/dbunit/annotation/ExpectedDatabase.java
@@ -45,12 +45,11 @@ public @interface ExpectedDatabase {
 	String value();
 
 	/**
-	 * If set to false will ignore unspecified tables and columns in expected data set when comparing to actual.
+	 * Database assertion mode to use. Default is {@link DatabaseAssertionMode#DEFAULT}.
 	 * <p>
-	 * Note: expected row order must match order in actual data set.
-	 * 
-	 * @return if data set compare must be strict
+	 * @return Database assertion mode to use.
 	 * @author Mario Zagar
 	 */
-	boolean strict() default true;
+	DatabaseAssertionMode assertionMode() default DatabaseAssertionMode.DEFAULT;
+
 }

--- a/src/main/java/org/springframework/test/dbunit/assertion/AbstractDatabaseAssertion.java
+++ b/src/main/java/org/springframework/test/dbunit/assertion/AbstractDatabaseAssertion.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2010 the original author or authors
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.test.dbunit.assertion;
+
+
+/**
+ * All specific database assertion implementations should derive from this class.
+ * 
+ * @author Mario Zagar
+ *
+ */
+abstract class AbstractDatabaseAssertion implements DatabaseAssertion {
+
+}

--- a/src/main/java/org/springframework/test/dbunit/assertion/DatabaseAssertion.java
+++ b/src/main/java/org/springframework/test/dbunit/assertion/DatabaseAssertion.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2010 the original author or authors
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.test.dbunit.assertion;
+
+import org.dbunit.DatabaseUnitException;
+import org.dbunit.dataset.IDataSet;
+
+/**
+ * Database assertion strategy interface.
+ * 
+ * @author Mario Zagar
+ *
+ */
+public interface DatabaseAssertion {
+
+	void assertEquals(IDataSet expectedDataSet, IDataSet actualDataSet) throws DatabaseUnitException;
+	
+}

--- a/src/main/java/org/springframework/test/dbunit/assertion/DatabaseAssertionFactory.java
+++ b/src/main/java/org/springframework/test/dbunit/assertion/DatabaseAssertionFactory.java
@@ -1,0 +1,31 @@
+package org.springframework.test.dbunit.assertion;
+
+import org.springframework.test.dbunit.annotation.DatabaseAssertionMode;
+
+/**
+ * Factory for specific database assertion strategy.
+ * 
+ * @author Mario Zagar
+ *
+ */
+public class DatabaseAssertionFactory {
+
+	/**
+	 * Returns specific database assertion implementation.
+	 * 
+	 * @param assertionMode for which to create database assertion implementation
+	 * @return specific database assertion implementation
+	 */
+	public static DatabaseAssertion createDatabaseAssertion(DatabaseAssertionMode assertionMode) {
+		if ( assertionMode == DatabaseAssertionMode.DEFAULT ) {
+			return new DefaultDatabaseAssertion();
+		}
+		
+		if ( assertionMode == DatabaseAssertionMode.NON_STRICT ) {
+			return new NonStrictDatabaseAssertion();
+		}
+		
+		throw new IllegalArgumentException("no database assertion implementation specified for: " + assertionMode);
+	}
+
+}

--- a/src/main/java/org/springframework/test/dbunit/assertion/DefaultDatabaseAssertion.java
+++ b/src/main/java/org/springframework/test/dbunit/assertion/DefaultDatabaseAssertion.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2010 the original author or authors
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.test.dbunit.assertion;
+
+import org.dbunit.Assertion;
+import org.dbunit.DatabaseUnitException;
+import org.dbunit.dataset.IDataSet;
+
+/**
+ * Default database assertion strategy which uses DbUnit {@link Assertion#assertEquals(IDataSet, IDataSet)}.
+ * 
+ * @author Mario Zagar
+ *
+ */
+class DefaultDatabaseAssertion extends AbstractDatabaseAssertion {
+
+	/**
+	 *  Uses DbUnit {@link Assertion#assertEquals(IDataSet, IDataSet)}.
+	 */
+	public void assertEquals(IDataSet expectedDataSet, IDataSet actualDataSet) throws DatabaseUnitException {
+		Assertion.assertEquals(expectedDataSet, actualDataSet);
+	}
+
+}

--- a/src/main/java/org/springframework/test/dbunit/assertion/NonStrictDatabaseAssertion.java
+++ b/src/main/java/org/springframework/test/dbunit/assertion/NonStrictDatabaseAssertion.java
@@ -1,4 +1,19 @@
-package org.springframework.test.dbunit.helper;
+/*
+ * Copyright 2010 the original author or authors
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.test.dbunit.assertion;
 
 import java.util.Arrays;
 import java.util.LinkedList;
@@ -13,22 +28,26 @@ import org.dbunit.dataset.IDataSet;
 import org.dbunit.dataset.ITableMetaData;
 
 /**
- * Implements helper methods for custom data set assertions.
+ * Implements non-strict database assertion strategy : compares data sets ignoring all tables and columns which are 
+ * not specified in expected data set but possibly exist in actual data set.
  * 
- * @author mzagar
- *
+ * @author Mario Zagar
  */
-public class AssertionHelper {
+class NonStrictDatabaseAssertion extends AbstractDatabaseAssertion {
 
 	/**
-	 * Compares data sets ignoring all tables and columns which are not specified in expectedDataSet but exist in 
-	 * actual data set.
+	 * Compares data sets ignoring all tables and columns which are not specified in expectedDataSet but 
+	 * possibly exist in actualDataSet.
 	 * 
 	 * @param expectedDataSet to compare with actual data set
 	 * @param actualDataSet to compare with expected data set
 	 * @throws DatabaseUnitException in case assertion fails
 	 */
-	public static void assertEqualsNonStrict(IDataSet expectedDataSet, IDataSet actualDataSet) throws DatabaseUnitException {
+	public void assertEquals(IDataSet expectedDataSet, IDataSet actualDataSet) throws DatabaseUnitException {
+		assertEqualsNonStrict(expectedDataSet, actualDataSet);
+	}
+	
+	private void assertEqualsNonStrict(IDataSet expectedDataSet, IDataSet actualDataSet) throws DatabaseUnitException {
 		// do not continue if same instance
 		if (expectedDataSet == actualDataSet) {
 		    return;
@@ -62,7 +81,5 @@ public class AssertionHelper {
         }
         Arrays.sort(names);
         return names;
-    }
+    }	
 }
-
-

--- a/src/test/java/org/springframework/test/dbunit/dbunittestexecutionlistener/expected/ExpectedNonStrictOnClassTest.java
+++ b/src/test/java/org/springframework/test/dbunit/dbunittestexecutionlistener/expected/ExpectedNonStrictOnClassTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2010 the original author or authors
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.test.dbunit.dbunittestexecutionlistener.expected;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
+import org.springframework.test.dbunit.DbUnitTestExecutionListener;
+import org.springframework.test.dbunit.annotation.DatabaseAssertionMode;
+import org.springframework.test.dbunit.annotation.ExpectedDatabase;
+import org.springframework.test.dbunit.entity.EntityAssert;
+import org.springframework.transaction.annotation.Transactional;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration("/META-INF/dbunit-context.xml")
+@TestExecutionListeners({ DependencyInjectionTestExecutionListener.class, DbUnitTestExecutionListener.class})
+@ExpectedDatabase(value="/META-INF/db/expected_nonstrict.xml", assertionMode=DatabaseAssertionMode.NON_STRICT)
+@Transactional
+public class ExpectedNonStrictOnClassTest {
+
+	@Autowired
+	private EntityAssert entityAssert;
+
+	@Test
+	public void test_nonstrict_does_not_throw_dbunit_exception_though_expected_table_does_not_specify_all_columns() throws Exception {
+		entityAssert.assertValues("existing1", "existing2");
+	}
+}

--- a/src/test/java/org/springframework/test/dbunit/dbunittestexecutionlistener/expected/ExpectedNonStrictOnMethodTest.java
+++ b/src/test/java/org/springframework/test/dbunit/dbunittestexecutionlistener/expected/ExpectedNonStrictOnMethodTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2010 the original author or authors
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.test.dbunit.dbunittestexecutionlistener.expected;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
+import org.springframework.test.dbunit.DbUnitTestExecutionListener;
+import org.springframework.test.dbunit.annotation.DatabaseAssertionMode;
+import org.springframework.test.dbunit.annotation.ExpectedDatabase;
+import org.springframework.test.dbunit.entity.EntityAssert;
+import org.springframework.transaction.annotation.Transactional;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration("/META-INF/dbunit-context.xml")
+@TestExecutionListeners({ DependencyInjectionTestExecutionListener.class, DbUnitTestExecutionListener.class})
+@Transactional
+public class ExpectedNonStrictOnMethodTest {
+
+	@Autowired
+	private EntityAssert entityAssert;
+
+	@Test
+	@ExpectedDatabase(value="/META-INF/db/expected_nonstrict.xml", assertionMode=DatabaseAssertionMode.NON_STRICT)
+	public void test_nonstrict_does_not_throw_dbunit_exception_though_expected_table_does_not_specify_all_columns() {
+		entityAssert.assertValues("existing1", "existing2");
+	}
+}

--- a/src/test/resources/META-INF/db/expected_nonstrict.xml
+++ b/src/test/resources/META-INF/db/expected_nonstrict.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dataset>
+	<SampleEntity value="existing1" />
+	<SampleEntity value="existing2" />
+</dataset>


### PR DESCRIPTION
Default value is 'true', which preserves original behavior of @ExpectedDatabase (table
count must match, all columns must be specified, ...). 'strict'
option does not affect row ordering - expected row count and ordering
must match those in actual data set.

Setting 'strict' to false will compare expected and actual data sets
ignoring tables and column names which are not specified in expected
data set but exist in actual data sets.

This can be useful during integration tests performed on live
databases containing multiple tables that have many columns, so one
must not specify all of them, but only the 'interesting' ones.
