### PR TITLE
Issue #5 fix

### DIFF
--- a/src/main/java/org/springframework/test/dbunit/DbUnitTestExecutionListener.java
+++ b/src/main/java/org/springframework/test/dbunit/DbUnitTestExecutionListener.java
@@ -135,6 +135,13 @@ public class DbUnitTestExecutionListener extends AbstractTestExecutionListener {
 	}
 
 	public void afterTestMethod(TestContext testContext) throws Exception {
+		
+		Throwable testException = testContext.getTestException();
+		
+		if ( testException != null ) {
+			throw new RuntimeException(testException);
+		}
+		
 		runner.afterTestMethod(new DbUnitTestContextAdapter(testContext));
 	}
 


### PR DESCRIPTION
DbUnitTestExecutionListener will re-throw any testexception that happened and will not continue to execute any dbunit tests.
