### PR TITLE
Added Identity Insert Operation Support

### DIFF
--- a/spring-test-dbunit/src/main/java/com/github/springtestdbunit/DbUnitRunner.java
+++ b/spring-test-dbunit/src/main/java/com/github/springtestdbunit/DbUnitRunner.java
@@ -1,17 +1,15 @@
 /*
  * Copyright 2010 the original author or authors
  * 
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.github.springtestdbunit;
 
@@ -21,15 +19,14 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.dbunit.database.IDatabaseConnection;
 import org.dbunit.dataset.IDataSet;
+import org.dbunit.ext.mssql.InsertIdentityOperation;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
-
 import com.github.springtestdbunit.annotation.DatabaseOperation;
 import com.github.springtestdbunit.annotation.DatabaseSetup;
 import com.github.springtestdbunit.annotation.DatabaseTearDown;
@@ -38,169 +35,184 @@ import com.github.springtestdbunit.assertion.DatabaseAssertion;
 import com.github.springtestdbunit.dataset.DataSetLoader;
 
 /**
- * Internal delegate class used to run tests with support for {@link DatabaseSetup &#064;DatabaseSetup},
- * {@link DatabaseTearDown &#064;DatabaseTearDown} and {@link ExpectedDatabase &#064;ExpectedDatabase} annotations.
+ * Internal delegate class used to run tests with support for {@link DatabaseSetup
+ * &#064;DatabaseSetup}, {@link DatabaseTearDown &#064;DatabaseTearDown} and
+ * {@link ExpectedDatabase &#064;ExpectedDatabase} annotations.
  * 
  * @author Phillip Webb
  * @author Mario Zagar
  */
 class DbUnitRunner {
 
-	private static final Log logger = LogFactory.getLog(DbUnitTestExecutionListener.class);
+  private static final Log logger = LogFactory.getLog(DbUnitTestExecutionListener.class);
 
-	private static Map<DatabaseOperation, org.dbunit.operation.DatabaseOperation> OPERATION_LOOKUP;
-	static {
-		OPERATION_LOOKUP = new HashMap<DatabaseOperation, org.dbunit.operation.DatabaseOperation>();
-		OPERATION_LOOKUP.put(DatabaseOperation.UPDATE, org.dbunit.operation.DatabaseOperation.UPDATE);
-		OPERATION_LOOKUP.put(DatabaseOperation.INSERT, org.dbunit.operation.DatabaseOperation.INSERT);
-		OPERATION_LOOKUP.put(DatabaseOperation.REFRESH, org.dbunit.operation.DatabaseOperation.REFRESH);
-		OPERATION_LOOKUP.put(DatabaseOperation.DELETE, org.dbunit.operation.DatabaseOperation.DELETE);
-		OPERATION_LOOKUP.put(DatabaseOperation.DELETE_ALL, org.dbunit.operation.DatabaseOperation.DELETE_ALL);
-		OPERATION_LOOKUP.put(DatabaseOperation.TRUNCATE_TABLE, org.dbunit.operation.DatabaseOperation.TRUNCATE_TABLE);
-		OPERATION_LOOKUP.put(DatabaseOperation.CLEAN_INSERT, org.dbunit.operation.DatabaseOperation.CLEAN_INSERT);
-	}
+  private static Map<DatabaseOperation, org.dbunit.operation.DatabaseOperation> OPERATION_LOOKUP;
+  static {
+    OPERATION_LOOKUP = new HashMap<DatabaseOperation, org.dbunit.operation.DatabaseOperation>();
+    OPERATION_LOOKUP.put(DatabaseOperation.UPDATE, org.dbunit.operation.DatabaseOperation.UPDATE);
+    OPERATION_LOOKUP.put(DatabaseOperation.INSERT, org.dbunit.operation.DatabaseOperation.INSERT);
+    OPERATION_LOOKUP.put(DatabaseOperation.REFRESH, org.dbunit.operation.DatabaseOperation.REFRESH);
+    OPERATION_LOOKUP.put(DatabaseOperation.DELETE, org.dbunit.operation.DatabaseOperation.DELETE);
+    OPERATION_LOOKUP.put(DatabaseOperation.DELETE_ALL, org.dbunit.operation.DatabaseOperation.DELETE_ALL);
+    OPERATION_LOOKUP.put(DatabaseOperation.TRUNCATE_TABLE, org.dbunit.operation.DatabaseOperation.TRUNCATE_TABLE);
+    OPERATION_LOOKUP.put(DatabaseOperation.CLEAN_INSERT, org.dbunit.operation.DatabaseOperation.CLEAN_INSERT);
+    OPERATION_LOOKUP.put(DatabaseOperation.MS_SQL_CLEAN_INSERT, new InsertIdentityOperation(org.dbunit.operation.DatabaseOperation.CLEAN_INSERT));
+  }
 
-	/**
-	 * Called before a test method is executed to perform any database setup.
-	 * @param testContext The test context
-	 * @throws Exception
-	 */
-	public void beforeTestMethod(DbUnitTestContext testContext) throws Exception {
-		Collection<DatabaseSetup> annotations = getAnnotations(testContext, DatabaseSetup.class);
-		setupOrTeardown(testContext, true, AnnotationAttributes.get(annotations));
-	}
+  /**
+   * Called before a test method is executed to perform any database setup.
+   * 
+   * @param testContext
+   *          The test context
+   * @throws Exception
+   */
+  public void beforeTestMethod(DbUnitTestContext testContext) throws Exception {
+    Collection<DatabaseSetup> annotations = getAnnotations(testContext, DatabaseSetup.class);
+    setupOrTeardown(testContext, true, AnnotationAttributes.get(annotations));
+  }
 
-	/**
-	 * Called after a test method is executed to perform any database teardown and to check expected results.
-	 * @param testContext The test context
-	 * @throws Exception
-	 */
-	public void afterTestMethod(DbUnitTestContext testContext) throws Exception {
-		try {
-			verifyExpected(testContext, getAnnotations(testContext, ExpectedDatabase.class));
-			Collection<DatabaseTearDown> annotations = getAnnotations(testContext, DatabaseTearDown.class);
-			try {
-				setupOrTeardown(testContext, false, AnnotationAttributes.get(annotations));
-			} catch (RuntimeException e) {
-				if (testContext.getTestException() == null) {
-					throw e;
-				}
-				if (logger.isWarnEnabled()) {
-					logger.warn("Unable to throw database cleanup exception due to existing test error", e);
-				}
-			}
-		} finally {
-			testContext.getConnection().close();
-		}
-	}
+  /**
+   * Called after a test method is executed to perform any database teardown and to check expected
+   * results.
+   * 
+   * @param testContext
+   *          The test context
+   * @throws Exception
+   */
+  public void afterTestMethod(DbUnitTestContext testContext) throws Exception {
+    try {
+      verifyExpected(testContext, getAnnotations(testContext, ExpectedDatabase.class));
+      Collection<DatabaseTearDown> annotations = getAnnotations(testContext, DatabaseTearDown.class);
+      try {
+        setupOrTeardown(testContext, false, AnnotationAttributes.get(annotations));
+      } catch (RuntimeException e) {
+        if (testContext.getTestException() == null) {
+          throw e;
+        }
+        if (logger.isWarnEnabled()) {
+          logger.warn("Unable to throw database cleanup exception due to existing test error", e);
+        }
+      }
+    } finally {
+      testContext.getConnection().close();
+    }
+  }
 
-	private <T extends Annotation> Collection<T> getAnnotations(DbUnitTestContext testContext, Class<T> annotationType) {
-		List<T> annotations = new ArrayList<T>();
-		addAnnotationToList(annotations, AnnotationUtils.findAnnotation(testContext.getTestClass(), annotationType));
-		addAnnotationToList(annotations, AnnotationUtils.findAnnotation(testContext.getTestMethod(), annotationType));
-		return annotations;
-	}
+  private <T extends Annotation> Collection<T> getAnnotations(DbUnitTestContext testContext,
+      Class<T> annotationType) {
+    List<T> annotations = new ArrayList<T>();
+    addAnnotationToList(annotations,
+        AnnotationUtils.findAnnotation(testContext.getTestClass(), annotationType));
+    addAnnotationToList(annotations,
+        AnnotationUtils.findAnnotation(testContext.getTestMethod(), annotationType));
+    return annotations;
+  }
 
-	private <T extends Annotation> void addAnnotationToList(List<T> annotations, T annotation) {
-		if (annotation != null) {
-			annotations.add(annotation);
-		}
-	}
+  private <T extends Annotation> void addAnnotationToList(List<T> annotations, T annotation) {
+    if (annotation != null) {
+      annotations.add(annotation);
+    }
+  }
 
-	private void verifyExpected(DbUnitTestContext testContext, Collection<ExpectedDatabase> annotations)
-			throws Exception {
-		if (testContext.getTestException() != null) {
-			if (logger.isDebugEnabled()) {
-				logger.debug("Skipping @DatabaseTest expectation due to test exception "
-						+ testContext.getTestException().getClass());
-			}
-			return;
-		}
-		IDatabaseConnection connection = testContext.getConnection();
-		IDataSet actualDataSet = connection.createDataSet();
-		for (ExpectedDatabase annotation : annotations) {
-			IDataSet expectedDataSet = loadDataset(testContext, annotation.value());
-			if (expectedDataSet != null) {
-				if (logger.isDebugEnabled()) {
-					logger.debug("Veriftying @DatabaseTest expectation using " + annotation.value());
-				}
-				DatabaseAssertion assertion = annotation.assertionMode().getDatabaseAssertion();
-				assertion.assertEquals(expectedDataSet, actualDataSet);
-			}
-		}
-	}
+  private void verifyExpected(DbUnitTestContext testContext,
+      Collection<ExpectedDatabase> annotations) throws Exception {
+    if (testContext.getTestException() != null) {
+      if (logger.isDebugEnabled()) {
+        logger.debug("Skipping @DatabaseTest expectation due to test exception "
+            + testContext.getTestException().getClass());
+      }
+      return;
+    }
+    IDatabaseConnection connection = testContext.getConnection();
+    IDataSet actualDataSet = connection.createDataSet();
+    for (ExpectedDatabase annotation : annotations) {
+      IDataSet expectedDataSet = loadDataset(testContext, annotation.value());
+      if (expectedDataSet != null) {
+        if (logger.isDebugEnabled()) {
+          logger.debug("Veriftying @DatabaseTest expectation using " + annotation.value());
+        }
+        DatabaseAssertion assertion = annotation.assertionMode().getDatabaseAssertion();
+        assertion.assertEquals(expectedDataSet, actualDataSet);
+      }
+    }
+  }
 
-	private IDataSet loadDataset(DbUnitTestContext testContext, String dataSetLocation) throws Exception {
-		DataSetLoader dataSetLoader = testContext.getDataSetLoader();
-		if (StringUtils.hasLength(dataSetLocation)) {
-			IDataSet dataSet = dataSetLoader.loadDataSet(testContext.getTestClass(), dataSetLocation);
-			Assert.notNull(dataSet,
-					"Unable to load dataset from \"" + dataSetLocation + "\" using " + dataSetLoader.getClass());
-			return dataSet;
-		}
-		return null;
-	}
+  private IDataSet loadDataset(DbUnitTestContext testContext, String dataSetLocation)
+      throws Exception {
+    DataSetLoader dataSetLoader = testContext.getDataSetLoader();
+    if (StringUtils.hasLength(dataSetLocation)) {
+      IDataSet dataSet = dataSetLoader.loadDataSet(testContext.getTestClass(), dataSetLocation);
+      Assert.notNull(dataSet, "Unable to load dataset from \"" + dataSetLocation + "\" using "
+          + dataSetLoader.getClass());
+      return dataSet;
+    }
+    return null;
+  }
 
-	private void setupOrTeardown(DbUnitTestContext testContext, boolean isSetup,
-			Collection<AnnotationAttributes> annotations) throws Exception {
-		IDatabaseConnection connection = testContext.getConnection();
-		DatabaseOperation lastOperation = null;
-		for (AnnotationAttributes annotation : annotations) {
-			for (String dataSetLocation : annotation.getValue()) {
-				DatabaseOperation operation = annotation.getType();
-				org.dbunit.operation.DatabaseOperation dbUnitDatabaseOperation = getDbUnitDatabaseOperation(operation,
-						lastOperation);
-				IDataSet dataSet = loadDataset(testContext, dataSetLocation);
-				if (dataSet != null) {
-					if (logger.isDebugEnabled()) {
-						logger.debug("Executing " + (isSetup ? "Setup" : "Teardown") + " of @DatabaseTest using "
-								+ operation + " on " + dataSetLocation);
-					}
-					dbUnitDatabaseOperation.execute(connection, dataSet);
-					lastOperation = operation;
-				}
-			}
-		}
-	}
+  private void setupOrTeardown(DbUnitTestContext testContext, boolean isSetup,
+      Collection<AnnotationAttributes> annotations) throws Exception {
+    IDatabaseConnection connection = testContext.getConnection();
+    DatabaseOperation lastOperation = null;
+    for (AnnotationAttributes annotation : annotations) {
+      for (String dataSetLocation : annotation.getValue()) {
+        DatabaseOperation operation = annotation.getType();
+        org.dbunit.operation.DatabaseOperation dbUnitDatabaseOperation = getDbUnitDatabaseOperation(
+            operation, lastOperation);
+        IDataSet dataSet = loadDataset(testContext, dataSetLocation);
+        if (dataSet != null) {
+          if (logger.isDebugEnabled()) {
+            logger.debug("Executing " + (isSetup ? "Setup" : "Teardown")
+                + " of @DatabaseTest using " + operation + " on " + dataSetLocation);
+          }
+          dbUnitDatabaseOperation.execute(connection, dataSet);
+          lastOperation = operation;
+        }
+      }
+    }
+  }
 
-	private org.dbunit.operation.DatabaseOperation getDbUnitDatabaseOperation(DatabaseOperation operation,
-			DatabaseOperation lastOperation) {
-		if ((operation == DatabaseOperation.CLEAN_INSERT) && (lastOperation == DatabaseOperation.CLEAN_INSERT)) {
-			operation = DatabaseOperation.INSERT;
-		}
-		org.dbunit.operation.DatabaseOperation databaseOperation = OPERATION_LOOKUP.get(operation);
-		Assert.state(databaseOperation != null, "The databse operation " + operation + " is not supported");
-		return databaseOperation;
-	}
+  private org.dbunit.operation.DatabaseOperation getDbUnitDatabaseOperation(
+      DatabaseOperation operation, DatabaseOperation lastOperation) {
+    if ((operation == DatabaseOperation.CLEAN_INSERT)
+        && (lastOperation == DatabaseOperation.CLEAN_INSERT)) {
+      operation = DatabaseOperation.INSERT;
+    }
+    org.dbunit.operation.DatabaseOperation databaseOperation = OPERATION_LOOKUP.get(operation);
+    Assert.state(databaseOperation != null, "The databse operation " + operation
+        + " is not supported");
+    return databaseOperation;
+  }
 
-	private static class AnnotationAttributes {
+  private static class AnnotationAttributes {
 
-		private DatabaseOperation type;
+    private DatabaseOperation type;
 
-		private String[] value;
+    private String[] value;
 
-		public AnnotationAttributes(Annotation annotation) {
-			Assert.state((annotation instanceof DatabaseSetup) || (annotation instanceof DatabaseTearDown),
-					"Only DatabaseSetup and DatabaseTearDown annotations are supported");
-			Map<String, Object> attributes = AnnotationUtils.getAnnotationAttributes(annotation);
-			this.type = (DatabaseOperation) attributes.get("type");
-			this.value = (String[]) attributes.get("value");
-		}
+    public AnnotationAttributes(Annotation annotation) {
+      Assert.state((annotation instanceof DatabaseSetup)
+          || (annotation instanceof DatabaseTearDown),
+          "Only DatabaseSetup and DatabaseTearDown annotations are supported");
+      Map<String, Object> attributes = AnnotationUtils.getAnnotationAttributes(annotation);
+      this.type = (DatabaseOperation)attributes.get("type");
+      this.value = (String[])attributes.get("value");
+    }
 
-		public DatabaseOperation getType() {
-			return this.type;
-		}
+    public DatabaseOperation getType() {
+      return this.type;
+    }
 
-		public String[] getValue() {
-			return this.value;
-		}
+    public String[] getValue() {
+      return this.value;
+    }
 
-		public static <T extends Annotation> Collection<AnnotationAttributes> get(Collection<T> annotations) {
-			List<AnnotationAttributes> annotationAttributes = new ArrayList<AnnotationAttributes>();
-			for (T annotation : annotations) {
-				annotationAttributes.add(new AnnotationAttributes(annotation));
-			}
-			return annotationAttributes;
-		}
-	}
+    public static <T extends Annotation> Collection<AnnotationAttributes> get(
+        Collection<T> annotations) {
+      List<AnnotationAttributes> annotationAttributes = new ArrayList<AnnotationAttributes>();
+      for (T annotation : annotations) {
+        annotationAttributes.add(new AnnotationAttributes(annotation));
+      }
+      return annotationAttributes;
+    }
+  }
 }

--- a/spring-test-dbunit/src/main/java/com/github/springtestdbunit/annotation/DatabaseOperation.java
+++ b/spring-test-dbunit/src/main/java/com/github/springtestdbunit/annotation/DatabaseOperation.java
@@ -1,17 +1,15 @@
 /*
  * Copyright 2010 the original author or authors
  * 
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.github.springtestdbunit.annotation;
 
@@ -25,46 +23,56 @@ package com.github.springtestdbunit.annotation;
  */
 public enum DatabaseOperation {
 
-	/**
-	 * Updates the contents of existing database tables from the dataset.
-	 */
-	UPDATE,
+  /**
+   * Updates the contents of existing database tables from the dataset.
+   */
+  UPDATE,
 
-	/**
-	 * Inserts new database tables and contents from the dataset.
-	 */
-	INSERT,
+  /**
+   * Inserts new database tables and contents from the dataset.
+   */
+  INSERT,
 
-	/**
-	 * Refresh the contents of existing database tables. Rows from the dataset will insert or replace existing data. Any
-	 * database rows that are not in the dataset remain unaffected.
-	 */
-	REFRESH,
+  /**
+   * Refresh the contents of existing database tables. Rows from the dataset will insert or replace
+   * existing data. Any database rows that are not in the dataset remain unaffected.
+   */
+  REFRESH,
 
-	/**
-	 * Deletes database table rows that matches rows from the dataset.
-	 */
-	DELETE,
+  /**
+   * Deletes database table rows that matches rows from the dataset.
+   */
+  DELETE,
 
-	/**
-	 * Deletes all rows from a database table when the table is specified in the dataset. Tables in the database but not
-	 * in the dataset remain unaffected.
-	 * @see #TRUNCATE_TABLE
-	 */
-	DELETE_ALL,
+  /**
+   * Deletes all rows from a database table when the table is specified in the dataset. Tables in
+   * the database but not in the dataset remain unaffected.
+   * 
+   * @see #TRUNCATE_TABLE
+   */
+  DELETE_ALL,
 
-	/**
-	 * Deletes all rows from a database table when the table is specified in the dataset. Tables in the database but not
-	 * in the dataset are unaffected. Identical to {@link #DELETE_ALL} expect this operation cannot be rolled back and
-	 * is supported by less database vendors.
-	 * @see #DELETE_ALL
-	 */
-	TRUNCATE_TABLE,
+  /**
+   * Deletes all rows from a database table when the table is specified in the dataset. Tables in
+   * the database but not in the dataset are unaffected. Identical to {@link #DELETE_ALL} expect
+   * this operation cannot be rolled back and is supported by less database vendors.
+   * 
+   * @see #DELETE_ALL
+   */
+  TRUNCATE_TABLE,
 
-	/**
-	 * Deletes all rows from a database table when the tables is specified in the dataset and subsequently insert new
-	 * contents. Equivalent to calling {@link #DELETE_ALL} followed by {@link #INSERT}.
-	 */
-	CLEAN_INSERT;
+  /**
+   * Deletes all rows from a database table when the tables is specified in the dataset and
+   * subsequently insert new contents. Equivalent to calling {@link #DELETE_ALL} followed by
+   * {@link #INSERT}.
+   */
+  CLEAN_INSERT,
+
+  /**
+   * Provides the same functionality as {@link #CLEAN_INSERT}, however this operation also enables
+   * the inserting on identity columns under MS SQL Server (i.e. sets {@code 'SET IDENTITY_INSERT
+   * (table) ON')}.
+   */
+  MS_SQL_CLEAN_INSERT;
 
 }


### PR DESCRIPTION
When executing integration tests against a MS SQL Server 2008 instance, I need to be able to use the org.dbunit.ext.mssql.InsertIdentityOperation so that I can insert on identity columns. This operation executes the "SET IDENTITY_INSERT <table> ON" statement that enables this.

The current spring-test-dbunit framework does not map this operation in com.github.springtestdbunit.DbUnitRunner and I am not provided with a way to add the mapped operation. 

This code allows for insertion on identity columns using the DBUnit IdentityInsertOperation.
