### PR TITLE
bug fix for issue #26

### DIFF
--- a/spring-test-dbunit/src/main/java/com/github/springtestdbunit/DbUnitRule.java
+++ b/spring-test-dbunit/src/main/java/com/github/springtestdbunit/DbUnitRule.java
@@ -208,8 +208,10 @@ public class DbUnitRule implements MethodRule {
 				this.nextStatement.evaluate();
 			} catch (Throwable e) {
 				this.testContext.setTestException(e);
+				throw e;
+			} finally {
+				runner.afterTestMethod(this.testContext);
 			}
-			runner.afterTestMethod(this.testContext);
 		}
 	}
 


### PR DESCRIPTION
https://github.com/springtestdbunit/spring-test-dbunit/issues/26

 Added specific test case to DbUnitRuleTest
 DbUnitStatement now rethrows exceptions from the wrapped statement

---

Quick fix for the issue. A weak point is that exceptions in runner.afterTestMethod() would suppress the exception from the test. Java 7's suppressed exception mechanism would be ideal here, but locks out older Java versions. On the other hand this simpler version may be sufficient.
