### PR TITLE
Added @ExpectedQuery annotation to expose assertEqualsByQuery DBUnit feature

### DIFF
--- a/spring-test-dbunit/src/main/java/com/github/springtestdbunit/annotation/ExpectedQuery.java
+++ b/spring-test-dbunit/src/main/java/com/github/springtestdbunit/annotation/ExpectedQuery.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2010 the original author or authors
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.springtestdbunit.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.github.springtestdbunit.DbUnitTestExecutionListener;
+import com.github.springtestdbunit.assertion.DatabaseAssertionMode;
+
+/**
+ * Test annotation that can be used to assert that a query dataset matches the expectations after tests have run.
+ * 
+ * @see DbUnitTestExecutionListener
+ * 
+ * @author Sunitha Rajarathnam
+ */
+@Documented
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.METHOD })
+public @interface ExpectedQuery {
+
+	/**
+	 * Provides the location of the dataset that will be used to test the database.
+	 * @return The dataset locations
+	 * @see DbUnitConfiguration#dataSetLoader()
+	 */
+	String value();
+
+    /**
+     * Database assertion mode to use. Default is {@link DatabaseAssertionMode#DEFAULT}.
+     * @return Database assertion mode to use.
+     */
+    DatabaseAssertionMode assertionMode() default DatabaseAssertionMode.DEFAULT;
+    
+    /**
+     * Provides the sqlquery that retrieves the actual subset of the table rows from the 
+     * database.
+     * 
+     * @return tableName
+     */
+	String sqlQuery();
+
+    /**
+     * Provides the name of the table that needs to be asserted.
+     * @return tableName
+     */
+    String tableName();
+    
+}

--- a/spring-test-dbunit/src/main/java/com/github/springtestdbunit/assertion/DatabaseAssertion.java
+++ b/spring-test-dbunit/src/main/java/com/github/springtestdbunit/assertion/DatabaseAssertion.java
@@ -15,7 +15,10 @@
  */
 package com.github.springtestdbunit.assertion;
 
+import java.sql.SQLException;
+
 import org.dbunit.DatabaseUnitException;
+import org.dbunit.database.IDatabaseConnection;
 import org.dbunit.dataset.IDataSet;
 
 /**
@@ -33,4 +36,15 @@ public interface DatabaseAssertion {
 	 */
 	void assertEquals(IDataSet expectedDataSet, IDataSet actualDataSet) throws DatabaseUnitException;
 
+	/**
+	 * Assert that the table from the dataset and the table generated from the sql query are conceptually equal.
+	 * 
+	 * @param expectedDataSet the expected dataset
+	 * @param connection the IDatabaseConnection
+	 * @param sqlQuery query that is used to generate the actual table data to be compared.
+	 * @param tableName name of the table that is compared.
+	 * @throws DatabaseUnitException if the tables data are not equal.
+	 * @throws SQLException 
+	 */
+	void assertEqualsByQuery(IDataSet expectedDataSet, IDatabaseConnection connection, String sqlQuery, String tableName) throws DatabaseUnitException, SQLException;
 }

--- a/spring-test-dbunit/src/main/java/com/github/springtestdbunit/assertion/DefaultDatabaseAssertion.java
+++ b/spring-test-dbunit/src/main/java/com/github/springtestdbunit/assertion/DefaultDatabaseAssertion.java
@@ -15,9 +15,13 @@
  */
 package com.github.springtestdbunit.assertion;
 
+import java.sql.SQLException;
+
 import org.dbunit.Assertion;
 import org.dbunit.DatabaseUnitException;
+import org.dbunit.database.IDatabaseConnection;
 import org.dbunit.dataset.IDataSet;
+import org.dbunit.dataset.ITable;
 
 /**
  * Default database assertion strategy which uses DbUnit {@link Assertion#assertEquals(IDataSet, IDataSet)}.
@@ -32,4 +36,15 @@ class DefaultDatabaseAssertion implements DatabaseAssertion {
 	public void assertEquals(IDataSet expectedDataSet, IDataSet actualDataSet) throws DatabaseUnitException {
 		Assertion.assertEquals(expectedDataSet, actualDataSet);
 	}
+	
+	/**
+	 * Uses DbUnit {@link Assertion#assertEquals(ITable, ITable)}.
+	 */
+    public void assertEqualsByQuery(IDataSet expectedDataSet, IDatabaseConnection connection,
+                                    String sqlQuery, String tableName) throws DatabaseUnitException, SQLException {
+        ITable expectedTable = expectedDataSet.getTable(tableName);
+        ITable actualTable = connection.createQueryTable(tableName, sqlQuery);
+        Assertion.assertEquals(expectedTable, actualTable);
+    }
+    
 }

--- a/spring-test-dbunit/src/main/java/com/github/springtestdbunit/assertion/NonStrictDatabaseAssertion.java
+++ b/spring-test-dbunit/src/main/java/com/github/springtestdbunit/assertion/NonStrictDatabaseAssertion.java
@@ -15,11 +15,13 @@
  */
 package com.github.springtestdbunit.assertion;
 
+import java.sql.SQLException;
 import java.util.LinkedList;
 import java.util.List;
 
 import org.dbunit.Assertion;
 import org.dbunit.DatabaseUnitException;
+import org.dbunit.database.IDatabaseConnection;
 import org.dbunit.dataset.Column;
 import org.dbunit.dataset.Columns;
 import org.dbunit.dataset.DataSetException;
@@ -46,6 +48,14 @@ class NonStrictDatabaseAssertion implements DatabaseAssertion {
 		}
 	}
 
+    public void assertEqualsByQuery(IDataSet expectedDataSet, IDatabaseConnection connection,
+                                    String sqlQuery, String tableName) throws DatabaseUnitException, SQLException {
+        ITable expectedTable = expectedDataSet.getTable(tableName);
+        ITable actualTable = connection.createQueryTable(tableName, sqlQuery);
+        String[] ignoredColumns = getColumnsToIgnore(expectedTable.getTableMetaData(), actualTable.getTableMetaData());
+        Assertion.assertEqualsIgnoreCols(expectedTable, actualTable, ignoredColumns);
+    }
+	
 	private String[] getColumnsToIgnore(ITableMetaData expectedMetaData, ITableMetaData actualMetaData)
 			throws DataSetException {
 		Column[] notSpecifiedInExpected = Columns.getColumnDiff(expectedMetaData, actualMetaData).getActual();
@@ -55,4 +65,5 @@ class NonStrictDatabaseAssertion implements DatabaseAssertion {
 		}
 		return result.toArray(new String[result.size()]);
 	}
+
 }

--- a/spring-test-dbunit/src/test/java/com/github/springtestdbunit/annotation/ExpectedQueryFailureOnMethodTest.java
+++ b/spring-test-dbunit/src/test/java/com/github/springtestdbunit/annotation/ExpectedQueryFailureOnMethodTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2010 the original author or authors
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.springtestdbunit.annotation;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.github.springtestdbunit.testutils.MustFailDbUnitTestExecutionListener;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration("/META-INF/dbunit-context.xml")
+@TestExecutionListeners({ DependencyInjectionTestExecutionListener.class, MustFailDbUnitTestExecutionListener.class })
+@Transactional
+public class ExpectedQueryFailureOnMethodTest {
+
+	@Test
+	@ExpectedQuery(value="/META-INF/db/expected_query.xml",sqlQuery="select * from SampleEntity where id=1",tableName="SampleEntity")
+	public void test() throws Exception {
+	}
+}

--- a/spring-test-dbunit/src/test/java/com/github/springtestdbunit/annotation/ExpectedQueryNonStrictFailureOnMethodTest.java
+++ b/spring-test-dbunit/src/test/java/com/github/springtestdbunit/annotation/ExpectedQueryNonStrictFailureOnMethodTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2010 the original author or authors
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.springtestdbunit.annotation;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.github.springtestdbunit.assertion.DatabaseAssertionMode;
+import com.github.springtestdbunit.testutils.MustFailDbUnitTestExecutionListener;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration("/META-INF/dbunit-context.xml")
+@TestExecutionListeners({ DependencyInjectionTestExecutionListener.class, MustFailDbUnitTestExecutionListener.class })
+@Transactional
+public class ExpectedQueryNonStrictFailureOnMethodTest {
+
+	@Test
+	@ExpectedQuery(value="/META-INF/db/expected_query_nonstrict.xml", assertionMode=DatabaseAssertionMode.NON_STRICT, sqlQuery="select * from SampleEntity where id=1", tableName="SampleEntity")
+	public void test() throws Exception {
+	}
+}

--- a/spring-test-dbunit/src/test/java/com/github/springtestdbunit/annotation/ExpectedQueryNonStrictOnMethodTest.java
+++ b/spring-test-dbunit/src/test/java/com/github/springtestdbunit/annotation/ExpectedQueryNonStrictOnMethodTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2010 the original author or authors
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.springtestdbunit.annotation;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.github.springtestdbunit.DbUnitTestExecutionListener;
+import com.github.springtestdbunit.assertion.DatabaseAssertionMode;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration("/META-INF/dbunit-context.xml")
+@TestExecutionListeners({ DependencyInjectionTestExecutionListener.class, DbUnitTestExecutionListener.class })
+@Transactional
+public class ExpectedQueryNonStrictOnMethodTest {
+
+	@Test
+	@ExpectedQuery(value="/META-INF/db/expected_query_nonstrict.xml", assertionMode=DatabaseAssertionMode.NON_STRICT,  sqlQuery="select * from SampleEntity where id in (1,2)",tableName="SampleEntity")
+	public void test() throws Exception {
+	}
+}

--- a/spring-test-dbunit/src/test/java/com/github/springtestdbunit/annotation/ExpectedQueryOnMethodTest.java
+++ b/spring-test-dbunit/src/test/java/com/github/springtestdbunit/annotation/ExpectedQueryOnMethodTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2010 the original author or authors
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.springtestdbunit.annotation;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.github.springtestdbunit.DbUnitTestExecutionListener;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration("/META-INF/dbunit-context.xml")
+@TestExecutionListeners({ DependencyInjectionTestExecutionListener.class, DbUnitTestExecutionListener.class })
+@Transactional
+public class ExpectedQueryOnMethodTest {
+
+	@Test
+	@ExpectedQuery(value="/META-INF/db/expected_query.xml",sqlQuery="select * from SampleEntity where id in (1,2)",tableName="SampleEntity")
+	public void test() throws Exception {
+	}
+}

--- a/spring-test-dbunit/src/test/resources/META-INF/db/expected_query.xml
+++ b/spring-test-dbunit/src/test/resources/META-INF/db/expected_query.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dataset>
+	<SampleEntity id="1" value="existing1" />
+	<SampleEntity id="2" value="existing2" />
+</dataset>

--- a/spring-test-dbunit/src/test/resources/META-INF/db/expected_query_nonstrict.xml
+++ b/spring-test-dbunit/src/test/resources/META-INF/db/expected_query_nonstrict.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dataset>
+	<SampleEntity value="existing1" />
+	<SampleEntity value="existing2" />
+</dataset>


### PR DESCRIPTION
We are using spring-test-dbunit in our team's Integration test Suite. We have this need to compare the expected xml against a subset of data in the database table. DBUnit itself has an assertEqualsByQuery that allows you to do that. I added a new annotation @ExpectedQuery that would help us use this particular DBUnit feature using the annotation. I believe the broader spring-test-dbunit community would benefit from this feature. Please review my changes and suggest any recommendations.

Thanks
Sunitha
