### PR TITLE
Added support for non-strict unordered assertion mode.

### DIFF
--- a/spring-test-dbunit/src/main/java/com/github/springtestdbunit/assertion/DatabaseAssertionMode.java
+++ b/spring-test-dbunit/src/main/java/com/github/springtestdbunit/assertion/DatabaseAssertionMode.java
@@ -22,6 +22,7 @@ import com.github.springtestdbunit.annotation.ExpectedDatabase;
  * Database assertion modes which determine {@link ExpectedDatabase} behaviour.
  * 
  * @author Mario Zagar
+ * @author Mehmet Aslan
  */
 public enum DatabaseAssertionMode {
 
@@ -40,7 +41,20 @@ public enum DatabaseAssertionMode {
 	 * rows.</li>
 	 * </ul>
 	 */
-	NON_STRICT(new NonStrictDatabaseAssertion());
+	NON_STRICT(new NonStrictDatabaseAssertion()),
+	
+	/**
+	 * Allows specifying only specific columns and tables in expected data set and ignoring row orders in expected and
+	 * actual data set. Unspecified tables and columns are ignored. Row orders in expected and actual data sets are
+	 * ignored. </p> <strong>Notes:</strong>
+	 * <ul>
+	 * <li>Expected row order does not need to match order in actual data set.</li>
+	 * <li>Specified columns must match in all rows, e.g. specifying 'column1' value without 'column2' value in one row
+	 * and only 'column2' value in another is not allowed - both 'column1' and 'column2' values must be specified in all
+	 * rows.</li>
+	 * </ul>
+	 */
+	NON_STRICT_UNORDERED(new NonStrictUnorderedDatabaseAssertion());
 
 	private DatabaseAssertion databaseAssertion;
 

--- a/spring-test-dbunit/src/main/java/com/github/springtestdbunit/assertion/NonStrictUnorderedDatabaseAssertion.java
+++ b/spring-test-dbunit/src/main/java/com/github/springtestdbunit/assertion/NonStrictUnorderedDatabaseAssertion.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2002-2013 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.springtestdbunit.assertion;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import org.dbunit.Assertion;
+import org.dbunit.DatabaseUnitException;
+import org.dbunit.dataset.Column;
+import org.dbunit.dataset.Columns;
+import org.dbunit.dataset.DataSetException;
+import org.dbunit.dataset.IDataSet;
+import org.dbunit.dataset.ITable;
+import org.dbunit.dataset.ITableMetaData;
+import org.dbunit.dataset.SortedTable;
+
+/**
+ * Implements non-strict unordered database assertion strategy : compares data sets ignoring all tables and columns
+ * which are not specified in expected data set but possibly exist in actual data set and sorting rows in expected and
+ * actual data sets with column order in expected data set to ignore row orders in expected and actual data sets.
+ * 
+ * @author Mario Zagar
+ * @author Sunitha Rajarathnam
+ * @author Mehmet Aslan
+ */
+class NonStrictUnorderedDatabaseAssertion implements DatabaseAssertion {
+
+	public void assertEquals(IDataSet expectedDataSet, IDataSet actualDataSet) throws DatabaseUnitException {
+		for (String tableName : expectedDataSet.getTableNames()) {
+			ITable expected = expectedDataSet.getTable(tableName);
+			ITable actual = actualDataSet.getTable(tableName);
+			String[] ignoredColumns = getColumnsToIgnore(expected.getTableMetaData(), actual.getTableMetaData());
+			Column[] expectedColumns = expected.getTableMetaData().getColumns();
+			Assertion.assertEqualsIgnoreCols(new SortedTable(expected, expectedColumns), new SortedTable(actual, expectedColumns), ignoredColumns);
+		}
+	}
+
+	public void assertEquals(ITable expectedTable, ITable actualTable) throws DatabaseUnitException {
+		String[] ignoredColumns = getColumnsToIgnore(expectedTable.getTableMetaData(), actualTable.getTableMetaData());
+		Assertion.assertEqualsIgnoreCols(expectedTable, actualTable, ignoredColumns);
+	}
+
+	private String[] getColumnsToIgnore(ITableMetaData expectedMetaData, ITableMetaData actualMetaData) throws DataSetException {
+		Column[] notSpecifiedInExpected = Columns.getColumnDiff(expectedMetaData, actualMetaData).getActual();
+		List<String> result = new LinkedList<String>();
+		for (Column column : notSpecifiedInExpected) {
+			result.add(column.getColumnName());
+		}
+		return result.toArray(new String[result.size()]);
+	}
+
+}

--- a/spring-test-dbunit/src/test/java/com/github/springtestdbunit/expected/ExpectedNonStrictUnorderedOnClassTest.java
+++ b/spring-test-dbunit/src/test/java/com/github/springtestdbunit/expected/ExpectedNonStrictUnorderedOnClassTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2002-2013 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.springtestdbunit.expected;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.github.springtestdbunit.DbUnitTestExecutionListener;
+import com.github.springtestdbunit.annotation.ExpectedDatabase;
+import com.github.springtestdbunit.assertion.DatabaseAssertionMode;
+import com.github.springtestdbunit.entity.EntityAssert;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration("/META-INF/dbunit-context.xml")
+@TestExecutionListeners({ DependencyInjectionTestExecutionListener.class, DbUnitTestExecutionListener.class })
+@ExpectedDatabase(value = "/META-INF/db/expected_nonstrict_unordered.xml", assertionMode = DatabaseAssertionMode.NON_STRICT_UNORDERED)
+@Transactional
+public class ExpectedNonStrictUnorderedOnClassTest {
+
+	@Autowired
+	private EntityAssert entityAssert;
+
+	@Test
+	public void shouldNotFailEvenThoughExpectedTableDoesNotSpecifyAllColumnsAndDoesNotMatchColumnOrders() throws Exception {
+		this.entityAssert.assertValues("existing1", "existing2");
+	}
+}

--- a/spring-test-dbunit/src/test/java/com/github/springtestdbunit/expected/ExpectedNonStrictUnorderedOnMethodTest.java
+++ b/spring-test-dbunit/src/test/java/com/github/springtestdbunit/expected/ExpectedNonStrictUnorderedOnMethodTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2002-2013 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.springtestdbunit.expected;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.github.springtestdbunit.DbUnitTestExecutionListener;
+import com.github.springtestdbunit.annotation.ExpectedDatabase;
+import com.github.springtestdbunit.assertion.DatabaseAssertionMode;
+import com.github.springtestdbunit.entity.EntityAssert;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration("/META-INF/dbunit-context.xml")
+@TestExecutionListeners({ DependencyInjectionTestExecutionListener.class, DbUnitTestExecutionListener.class })
+@Transactional
+public class ExpectedNonStrictUnorderedOnMethodTest {
+
+	@Autowired
+	private EntityAssert entityAssert;
+
+	@Test
+	@ExpectedDatabase(value = "/META-INF/db/expected_nonstrict_unordered.xml", assertionMode = DatabaseAssertionMode.NON_STRICT_UNORDERED)
+	public void shouldNotFailEvenThoughExpectedTableDoesNotSpecifyAllColumnsAndDoesNotMatchColumnOrders() {
+		this.entityAssert.assertValues("existing1", "existing2");
+	}
+}

--- a/spring-test-dbunit/src/test/resources/META-INF/db/expected_nonstrict_unordered.xml
+++ b/spring-test-dbunit/src/test/resources/META-INF/db/expected_nonstrict_unordered.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dataset>
+	<SampleEntity value="existing2" />
+	<SampleEntity value="existing1" />
+</dataset>


### PR DESCRIPTION
Added a new mode "NON_STRICT_UNORDERED" to DatabaseAssertionMode enum to be able to compare actual and expected data ignoring order of rows. Corresponding class to this mode sorts two data sets using SortedTable.

When using only NON_STRICT mode, our test cases pass sometimes but fails sometimes because the order of actual data can not match expected data every time so we need to this behaviour.
