### PR TITLE
Add @ExpectedCompositeDatabase annotation

### DIFF
--- a/spring-test-dbunit/src/main/java/com/github/springtestdbunit/DbUnitRunner.java
+++ b/spring-test-dbunit/src/main/java/com/github/springtestdbunit/DbUnitRunner.java
@@ -18,6 +18,7 @@ package com.github.springtestdbunit;
 
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -34,17 +35,22 @@ import org.springframework.util.StringUtils;
 import com.github.springtestdbunit.annotation.DatabaseOperation;
 import com.github.springtestdbunit.annotation.DatabaseSetup;
 import com.github.springtestdbunit.annotation.DatabaseTearDown;
+import com.github.springtestdbunit.annotation.ExpectedCompositeDatabase;
 import com.github.springtestdbunit.annotation.ExpectedDatabase;
 import com.github.springtestdbunit.assertion.DatabaseAssertion;
+import com.github.springtestdbunit.assertion.DatabaseAssertionMode;
+import com.github.springtestdbunit.dataset.CompositeDataSetLoader;
 import com.github.springtestdbunit.dataset.DataSetLoader;
 
 /**
  * Internal delegate class used to run tests with support for {@link DatabaseSetup &#064;DatabaseSetup},
- * {@link DatabaseTearDown &#064;DatabaseTearDown} and {@link ExpectedDatabase &#064;ExpectedDatabase} annotations.
+ * {@link DatabaseTearDown &#064;DatabaseTearDown}, {@link ExpectedDatabase &#064;ExpectedDatabase} and
+ * {@link ExpectedCompositeDatabase &#064;ExpectedCompositeDatabase} annotations.
  * 
  * @author Phillip Webb
  * @author Mario Zagar
  * @author Sunitha Rajarathnam
+ * @author Vseslav Suvorov
  */
 class DbUnitRunner {
 
@@ -67,7 +73,8 @@ class DbUnitRunner {
 	 */
 	public void afterTestMethod(DbUnitTestContext testContext) throws Exception {
 		try {
-			verifyExpected(testContext, getAnnotations(testContext, ExpectedDatabase.class));
+			verifyExpected(testContext, new ExpectedDatabaseAccessor());
+			verifyExpected(testContext, new ExpectedCompositeDatabaseAccessor());
 			Collection<DatabaseTearDown> annotations = getAnnotations(testContext, DatabaseTearDown.class);
 			try {
 				setupOrTeardown(testContext, false, AnnotationAttributes.get(annotations));
@@ -84,21 +91,22 @@ class DbUnitRunner {
 		}
 	}
 
-	private <T extends Annotation> Collection<T> getAnnotations(DbUnitTestContext testContext, Class<T> annotationType) {
+	private static <T extends Annotation> Collection<T> getAnnotations(DbUnitTestContext testContext,
+			Class<T> annotationType) {
 		List<T> annotations = new ArrayList<T>();
 		addAnnotationToList(annotations, AnnotationUtils.findAnnotation(testContext.getTestClass(), annotationType));
 		addAnnotationToList(annotations, AnnotationUtils.findAnnotation(testContext.getTestMethod(), annotationType));
 		return annotations;
 	}
 
-	private <T extends Annotation> void addAnnotationToList(List<T> annotations, T annotation) {
+	private static <T extends Annotation> void addAnnotationToList(List<T> annotations, T annotation) {
 		if (annotation != null) {
 			annotations.add(annotation);
 		}
 	}
-
-	private void verifyExpected(DbUnitTestContext testContext, Collection<ExpectedDatabase> annotations)
-			throws Exception {
+	
+	private <T extends Annotation> void verifyExpected(DbUnitTestContext testContext,
+			ExpectedAnnotationAccessor<T> expectedAccessor) throws Exception {
 		if (testContext.getTestException() != null) {
 			if (logger.isDebugEnabled()) {
 				logger.debug("Skipping @DatabaseTest expectation due to test exception "
@@ -107,15 +115,16 @@ class DbUnitRunner {
 			return;
 		}
 		IDatabaseConnection connection = testContext.getConnection();
-		for (ExpectedDatabase annotation : annotations) {
-			String query = annotation.query();
-			String table = annotation.table();
-			IDataSet expectedDataSet = loadDataset(testContext, annotation.value());
+		for (T annotation : expectedAccessor.getAnnotations(testContext)) {
+			String query = expectedAccessor.query(annotation);
+			String table = expectedAccessor.table(annotation);
+			IDataSet expectedDataSet = expectedAccessor.loadDataset(testContext, annotation);
 			if (expectedDataSet != null) {
 				if (logger.isDebugEnabled()) {
-					logger.debug("Veriftying @DatabaseTest expectation using " + annotation.value());
+					logger.debug("Veriftying @DatabaseTest expectation using "
+							+ expectedAccessor.valueAsString(annotation));
 				}
-				DatabaseAssertion assertion = annotation.assertionMode().getDatabaseAssertion();
+				DatabaseAssertion assertion = expectedAccessor.assertionMode(annotation).getDatabaseAssertion();
 				if (StringUtils.hasLength(query)) {
 					Assert.hasLength(table, "The table name must be specified when using a SQL query");
 					ITable expectedTable = expectedDataSet.getTable(table);
@@ -133,12 +142,29 @@ class DbUnitRunner {
 		}
 	}
 
-	private IDataSet loadDataset(DbUnitTestContext testContext, String dataSetLocation) throws Exception {
+	private static IDataSet loadDataset(DbUnitTestContext testContext, String dataSetLocation) throws Exception {
 		DataSetLoader dataSetLoader = testContext.getDataSetLoader();
 		if (StringUtils.hasLength(dataSetLocation)) {
 			IDataSet dataSet = dataSetLoader.loadDataSet(testContext.getTestClass(), dataSetLocation);
 			Assert.notNull(dataSet,
 					"Unable to load dataset from \"" + dataSetLocation + "\" using " + dataSetLoader.getClass());
+			return dataSet;
+		}
+		return null;
+	}
+
+	private static IDataSet loadDataset(DbUnitTestContext testContext, String[] dataSetLocations,
+			boolean combine, boolean caseSensitiveTableNames) throws Exception {
+		DataSetLoader dataSetLoader = testContext.getDataSetLoader();
+		Assert.isInstanceOf(CompositeDataSetLoader.class, dataSetLoader,
+				"Invalid data set loader is specified: ");
+		CompositeDataSetLoader compositeDataSetLoader = (CompositeDataSetLoader) dataSetLoader;
+		if (dataSetLocations.length > 0) {
+			IDataSet dataSet = compositeDataSetLoader.loadDataSet(testContext.getTestClass(), dataSetLocations,
+					combine, caseSensitiveTableNames);
+			Assert.notNull(dataSet,
+					"Unable to load dataset from \"" + Arrays.toString(dataSetLocations)
+							+ "\" using " + dataSetLoader.getClass());
 			return dataSet;
 		}
 		return null;
@@ -173,7 +199,7 @@ class DbUnitRunner {
 		}
 		org.dbunit.operation.DatabaseOperation databaseOperation = testContext.getDatbaseOperationLookup().get(
 				operation);
-		Assert.state(databaseOperation != null, "The databse operation " + operation + " is not supported");
+		Assert.state(databaseOperation != null, "The database operation " + operation + " is not supported");
 		return databaseOperation;
 	}
 
@@ -205,6 +231,78 @@ class DbUnitRunner {
 				annotationAttributes.add(new AnnotationAttributes(annotation));
 			}
 			return annotationAttributes;
+		}
+	}
+	
+	private interface ExpectedAnnotationAccessor<T extends Annotation> {
+		
+		Collection<T> getAnnotations(DbUnitTestContext testContext);
+
+		String valueAsString(T annotation);
+		
+		IDataSet loadDataset(DbUnitTestContext testContext, T annotation) throws Exception;
+		
+		DatabaseAssertionMode assertionMode(T annotation);
+		
+		String table(T annotation);
+		
+		String query(T annotation);
+	}
+	
+	private static class ExpectedDatabaseAccessor implements ExpectedAnnotationAccessor<ExpectedDatabase> {
+
+		public Collection<ExpectedDatabase> getAnnotations(DbUnitTestContext testContext) {
+			return DbUnitRunner.getAnnotations(testContext, ExpectedDatabase.class);
+		}
+
+		public String valueAsString(ExpectedDatabase annotation) {
+			return annotation.value();
+		}
+
+		public IDataSet loadDataset(DbUnitTestContext testContext, ExpectedDatabase annotation) throws Exception {
+			return DbUnitRunner.loadDataset(testContext, annotation.value());
+		}
+
+		public DatabaseAssertionMode assertionMode(ExpectedDatabase annotation) {
+			return annotation.assertionMode();
+		}
+
+		public String table(ExpectedDatabase annotation) {
+			return annotation.table();
+		}
+
+		public String query(ExpectedDatabase annotation) {
+			return annotation.query();
+		}
+	}
+	
+	private static class ExpectedCompositeDatabaseAccessor implements
+			ExpectedAnnotationAccessor<ExpectedCompositeDatabase> {
+
+		public Collection<ExpectedCompositeDatabase> getAnnotations(DbUnitTestContext testContext) {
+			return DbUnitRunner.getAnnotations(testContext, ExpectedCompositeDatabase.class);
+		}
+
+		public String valueAsString(ExpectedCompositeDatabase annotation) {
+			return Arrays.toString(annotation.value());
+		}
+
+		public IDataSet loadDataset(DbUnitTestContext testContext, ExpectedCompositeDatabase annotation)
+				throws Exception {
+			return DbUnitRunner.loadDataset(testContext, annotation.value(), annotation.combine(),
+					annotation.caseSensitiveTableNames());
+		}
+
+		public DatabaseAssertionMode assertionMode(ExpectedCompositeDatabase annotation) {
+			return annotation.assertionMode();
+		}
+
+		public String table(ExpectedCompositeDatabase annotation) {
+			return annotation.table();
+		}
+
+		public String query(ExpectedCompositeDatabase annotation) {
+			return annotation.query();
 		}
 	}
 }

--- a/spring-test-dbunit/src/main/java/com/github/springtestdbunit/DbUnitTestExecutionListener.java
+++ b/spring-test-dbunit/src/main/java/com/github/springtestdbunit/DbUnitTestExecutionListener.java
@@ -36,6 +36,7 @@ import org.springframework.util.StringUtils;
 import com.github.springtestdbunit.annotation.DatabaseSetup;
 import com.github.springtestdbunit.annotation.DatabaseTearDown;
 import com.github.springtestdbunit.annotation.DbUnitConfiguration;
+import com.github.springtestdbunit.annotation.ExpectedCompositeDatabase;
 import com.github.springtestdbunit.annotation.ExpectedDatabase;
 import com.github.springtestdbunit.bean.DatabaseDataSourceConnectionFactoryBean;
 import com.github.springtestdbunit.dataset.DataSetLoader;
@@ -45,7 +46,8 @@ import com.github.springtestdbunit.operation.DefaultDatabaseOperationLookup;
 
 /**
  * <code>TestExecutionListener</code> which provides support for {@link DatabaseSetup &#064;DatabaseSetup},
- * {@link DatabaseTearDown &#064;DatabaseTearDown} and {@link ExpectedDatabase &#064;ExpectedDatabase} annotations.
+ * {@link DatabaseTearDown &#064;DatabaseTearDown}, {@link ExpectedDatabase &#064;ExpectedDatabase} and
+ * {@link ExpectedCompositeDatabase &#064;ExpectedCompositeDatabase} annotations.
  * <p>
  * A bean named "<tt>dbUnitDatabaseConnection</tt>" or "<tt>dataSource</tt>" is expected in the
  * <tt>ApplicationContext</tt> associated with the test. This bean can contain either a {@link IDatabaseConnection} or a

--- a/spring-test-dbunit/src/main/java/com/github/springtestdbunit/annotation/ExpectedCompositeDatabase.java
+++ b/spring-test-dbunit/src/main/java/com/github/springtestdbunit/annotation/ExpectedCompositeDatabase.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2002-2013 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.springtestdbunit.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.github.springtestdbunit.DbUnitTestExecutionListener;
+import com.github.springtestdbunit.assertion.DatabaseAssertionMode;
+
+/**
+ * Test annotation that can be used to assert that a database is in given state after tests have run. This annotations
+ * differs from {@link ExpectedDatabase &#064;ExpectedDatabase} in that this one allows to specify multiple locations of
+ * the composite dataset.
+ * 
+ * @see DbUnitTestExecutionListener
+ * 
+ * @author Vseslav Suvorov
+ */
+@Documented
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.METHOD })
+public @interface ExpectedCompositeDatabase {
+
+	/**
+	 * Provides the locations of the composite dataset that will be used to test the database.
+	 * 
+	 * @return The dataset locations
+	 * @see DbUnitConfiguration#dataSetLoader()
+	 */
+	String[] value();
+
+	/**
+	 * If <tt>true</tt>, tables having the same name are merged into one table. Default is <tt>true</tt>.
+	 * 
+	 * @return A flag that allows to combine tables with the same name
+	 */
+	boolean combine() default true;
+
+	/**
+	 * Whether or not table names are handled in a case sensitive way over all datasets. Default is <tt>false</tt>.
+	 * 
+	 * @return Case sensitivity of table names
+	 */
+	boolean caseSensitiveTableNames() default false;
+
+	/**
+	 * Database assertion mode to use. Default is {@link DatabaseAssertionMode#DEFAULT}.
+	 * 
+	 * @return Database assertion mode to use
+	 */
+	DatabaseAssertionMode assertionMode() default DatabaseAssertionMode.DEFAULT;
+
+	/**
+	 * Optional table name that can be used to limit the comparison to a specific table.
+	 * 
+	 * @return the table name
+	 */
+	String table() default "";
+
+	/**
+	 * Optional SQL to retrieve the actual subset of the table rows from the database. NOTE: a {@link #table() table
+	 * name} must also be specified when using a query.
+	 * 
+	 * @return the SQL Query
+	 */
+	String query() default "";
+
+}

--- a/spring-test-dbunit/src/main/java/com/github/springtestdbunit/dataset/AbstractDataSetLoader.java
+++ b/spring-test-dbunit/src/main/java/com/github/springtestdbunit/dataset/AbstractDataSetLoader.java
@@ -16,6 +16,10 @@
 
 package com.github.springtestdbunit.dataset;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.dbunit.dataset.CompositeDataSet;
 import org.dbunit.dataset.IDataSet;
 import org.springframework.core.io.ClassRelativeResourceLoader;
 import org.springframework.core.io.Resource;
@@ -27,12 +31,13 @@ import org.springframework.core.io.ResourceLoader;
  * Spring {@link #getResourceLoader resource loader}.
  * 
  * @author Phillip Webb
+ * @author Vseslav Suvorov
  * 
  * @see #getResourceLoader
  * @see #getResourceLocations
  * @see #createDataSet(Resource)
  */
-public abstract class AbstractDataSetLoader implements DataSetLoader {
+public abstract class AbstractDataSetLoader implements DataSetLoader, CompositeDataSetLoader {
 
 	/**
 	 * Loads a {@link IDataSet dataset} from {@link Resource}s obtained from the specified <tt>location</tt>. Each
@@ -55,6 +60,33 @@ public abstract class AbstractDataSetLoader implements DataSetLoader {
 			}
 		}
 		return null;
+	}
+
+	/**
+	 * Load and return a composite {@link IDataSet dataset} from the multiple {@code locations}. Each location is loaded
+	 * using {@link AbstractDataSetLoader#loadDataSet(Class, String)} and then all the datasets are combined into the
+	 * single dataset.
+	 * <p>
+	 * If none of resources can be found then {@code null} will be returned.
+	 * 
+	 * @param testClass The class under test
+	 * @param locations The locations to load
+	 * @param combine if <tt>true</tt>, tables having the same name are merged into one table
+	 * @param caseSensitiveTableNames Whether or not table names are handled in a case sensitive way over all datasets
+	 * @return a {@link IDataSet dataset} or {@code null}
+	 * @throws Exception If the {@link IDataSet dataset} cannot be loaded
+	 */
+	public IDataSet loadDataSet(Class<?> testClass, String[] locations, boolean combine, boolean caseSensitiveTableNames)
+			throws Exception {
+		List<IDataSet> dataSets = new ArrayList<IDataSet>(locations.length);
+		for (String location : locations) {
+			IDataSet dataSet = loadDataSet(testClass, location);
+			if (dataSet != null) {
+				dataSets.add(dataSet);
+			}
+		}
+		return dataSets.isEmpty() ? null : new CompositeDataSet(dataSets.toArray(new IDataSet[dataSets.size()]),
+				combine, caseSensitiveTableNames);
 	}
 
 	/**

--- a/spring-test-dbunit/src/main/java/com/github/springtestdbunit/dataset/CompositeDataSetLoader.java
+++ b/spring-test-dbunit/src/main/java/com/github/springtestdbunit/dataset/CompositeDataSetLoader.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2002-2013 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.springtestdbunit.dataset;
+
+import org.dbunit.dataset.IDataSet;
+
+/**
+ * Strategy interface for {@link #loadDataSet loading} a composite {@link IDataSet dataset} from the multiple locations.
+ * <p>
+ * Concrete implementations must provide a <code>public</code> no-args constructor.
+ * 
+ * @author Vseslav Suvorov
+ * 
+ * @see FlatXmlDataSetLoader
+ */
+public interface CompositeDataSetLoader {
+
+	/**
+	 * Load and return a composite {@link IDataSet dataset} from the multiple <tt>locations</tt>. If the dataset cannot
+	 * be found <tt>null</tt> may be returned.
+	 * 
+	 * @param testClass The class under test
+	 * @param locations The locations to load
+	 * @param combine if <tt>true</tt>, tables having the same name are merged into one table
+	 * @param caseSensitiveTableNames Whether or not table names are handled in a case sensitive way over all datasets
+	 * @return a {@link IDataSet dataset} or <tt>null</tt>
+	 * @throws Exception If the {@link IDataSet dataset} cannot be loaded
+	 */
+	public IDataSet loadDataSet(Class<?> testClass, String[] locations, boolean combine, boolean caseSensitiveTableNames)
+			throws Exception;
+}

--- a/spring-test-dbunit/src/test/java/com/github/springtestdbunit/dataset/FlatXmlDataSetLoaderTests.java
+++ b/spring-test-dbunit/src/test/java/com/github/springtestdbunit/dataset/FlatXmlDataSetLoaderTests.java
@@ -18,6 +18,7 @@ package com.github.springtestdbunit.dataset;
 
 import static org.junit.Assert.*;
 
+import org.dbunit.Assertion;
 import org.dbunit.dataset.IDataSet;
 import org.junit.Before;
 import org.junit.Test;
@@ -53,5 +54,13 @@ public class FlatXmlDataSetLoaderTests {
 	public void shouldReturnNullOnMissingFile() throws Exception {
 		IDataSet dataset = this.loader.loadDataSet(this.testContext.getTestClass(), "doesnotexist.xml");
 		assertNull(dataset);
+	}
+	
+	@Test
+	public void shouldLoadCompositeDataSet() throws Exception {
+		String[] locations = new String[] {"part1.xml", "part2.xml"};
+		IDataSet dataset = this.loader.loadDataSet(this.testContext.getTestClass(), locations, true, false);
+		IDataSet expectedDataSet = this.loader.loadDataSet(this.testContext.getTestClass(), "composite.xml");
+		Assertion.assertEquals(expectedDataSet, dataset);
 	}
 }

--- a/spring-test-dbunit/src/test/java/com/github/springtestdbunit/expected/ExpectedCompositeOnClassTest.java
+++ b/spring-test-dbunit/src/test/java/com/github/springtestdbunit/expected/ExpectedCompositeOnClassTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2002-2013 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.springtestdbunit.expected;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.github.springtestdbunit.DbUnitTestExecutionListener;
+import com.github.springtestdbunit.annotation.ExpectedCompositeDatabase;
+import com.github.springtestdbunit.assertion.DatabaseAssertionMode;
+import com.github.springtestdbunit.entity.EntityAssert;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration("/META-INF/dbunit-context.xml")
+@TestExecutionListeners({ DependencyInjectionTestExecutionListener.class, DbUnitTestExecutionListener.class })
+@ExpectedCompositeDatabase(value = { "/META-INF/db/expected_composite_part1.xml",
+		"/META-INF/db/expected_composite_part2.xml" }, assertionMode = DatabaseAssertionMode.NON_STRICT)
+@Transactional
+public class ExpectedCompositeOnClassTest {
+
+	@Autowired
+	private EntityAssert entityAssert;
+
+	@Test
+	public void shouldExpectCompositeDatabase() throws Exception {
+		this.entityAssert.assertValues("existing1", "existing2");
+	}
+}

--- a/spring-test-dbunit/src/test/java/com/github/springtestdbunit/expected/ExpectedCompositeOnMethodTest.java
+++ b/spring-test-dbunit/src/test/java/com/github/springtestdbunit/expected/ExpectedCompositeOnMethodTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2002-2013 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.springtestdbunit.expected;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.github.springtestdbunit.DbUnitTestExecutionListener;
+import com.github.springtestdbunit.annotation.ExpectedCompositeDatabase;
+import com.github.springtestdbunit.assertion.DatabaseAssertionMode;
+import com.github.springtestdbunit.entity.EntityAssert;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration("/META-INF/dbunit-context.xml")
+@TestExecutionListeners({ DependencyInjectionTestExecutionListener.class, DbUnitTestExecutionListener.class })
+@Transactional
+public class ExpectedCompositeOnMethodTest {
+
+	@Autowired
+	private EntityAssert entityAssert;
+
+	@Test
+	@ExpectedCompositeDatabase(value = { "/META-INF/db/expected_composite_part1.xml",
+			"/META-INF/db/expected_composite_part2.xml" }, assertionMode = DatabaseAssertionMode.NON_STRICT)
+	public void shouldNotFailEvenThoughExpectedTableDoesNotSpecifyAllColumns() {
+		this.entityAssert.assertValues("existing1", "existing2");
+	}
+}

--- a/spring-test-dbunit/src/test/resources/META-INF/db/expected_composite_part1.xml
+++ b/spring-test-dbunit/src/test/resources/META-INF/db/expected_composite_part1.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dataset>
+	<SampleEntity value="existing1" />
+</dataset>

--- a/spring-test-dbunit/src/test/resources/META-INF/db/expected_composite_part2.xml
+++ b/spring-test-dbunit/src/test/resources/META-INF/db/expected_composite_part2.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dataset>
+	<SampleEntity value="existing2" />
+</dataset>

--- a/spring-test-dbunit/src/test/resources/com/github/springtestdbunit/dataset/composite.xml
+++ b/spring-test-dbunit/src/test/resources/com/github/springtestdbunit/dataset/composite.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dataset>
+	<table1 column1="1"/>
+	<table2 column2="2"/>
+	<table2 column2="A"/>
+	<table3 column3="B"/>
+</dataset>

--- a/spring-test-dbunit/src/test/resources/com/github/springtestdbunit/dataset/part1.xml
+++ b/spring-test-dbunit/src/test/resources/com/github/springtestdbunit/dataset/part1.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dataset>
+	<table1 column1="1"/>
+	<table2 column2="2"/>
+</dataset>

--- a/spring-test-dbunit/src/test/resources/com/github/springtestdbunit/dataset/part2.xml
+++ b/spring-test-dbunit/src/test/resources/com/github/springtestdbunit/dataset/part2.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dataset>
+	<table2 column2="A"/>
+	<table3 column3="B"/>
+</dataset>


### PR DESCRIPTION
Hi,

I have a common part of the expected XML file for each unit test. This large part depends on the database schema and it is repeated for each test. Every time I'm slightly changing the database schema, all the tests fail. This is okay, but I have to fix all the tests independently. So I decided to extract a common part into the separate file.

Unfortunately @ExpectedCompositeDatabase does not allow me to configure multiple XML files just like @DatabaseSetup. So I created a new annotation: @ExpectedCompositeDatabase. Could you please accept my pull request for this feature?
