### PR TITLE
make field nullable and table column sensitive

### DIFF
--- a/spring-test-dbunit/src/main/java/com/github/springtestdbunit/dataset/FlatXmlDataSetLoader.java
+++ b/spring-test-dbunit/src/main/java/com/github/springtestdbunit/dataset/FlatXmlDataSetLoader.java
@@ -19,6 +19,7 @@ package com.github.springtestdbunit.dataset;
 import java.io.InputStream;
 
 import org.dbunit.dataset.IDataSet;
+import org.dbunit.dataset.ReplacementDataSet;
 import org.dbunit.dataset.xml.FlatXmlDataSet;
 import org.dbunit.dataset.xml.FlatXmlDataSetBuilder;
 import org.springframework.core.io.Resource;
@@ -33,9 +34,14 @@ public class FlatXmlDataSetLoader extends AbstractDataSetLoader {
 	@Override
 	protected IDataSet createDataSet(Resource resource) throws Exception {
 		FlatXmlDataSetBuilder builder = new FlatXmlDataSetBuilder();
+		builder.setColumnSensing(true);
 		InputStream inputStream = resource.getInputStream();
 		try {
-			return builder.build(inputStream);
+			FlatXmlDataSet flatXmlDataSet= builder.build(inputStream);
+			ReplacementDataSet dataSet = new ReplacementDataSet(flatXmlDataSet); 
+			dataSet.setStrictReplacement(true);
+			dataSet.addReplacementObject("[NULL]", null);
+			return dataSet;
 		} finally {
 			inputStream.close();
 		}

--- a/spring-test-dbunit/src/test/java/com/github/springtestdbunit/dataset/FlatXmlDataSetLoaderTests.java
+++ b/spring-test-dbunit/src/test/java/com/github/springtestdbunit/dataset/FlatXmlDataSetLoaderTests.java
@@ -19,6 +19,7 @@ package com.github.springtestdbunit.dataset;
 import static org.junit.Assert.*;
 
 import org.dbunit.dataset.IDataSet;
+import org.dbunit.dataset.xml.FlatXmlDataSet;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.test.context.TestContext;
@@ -43,6 +44,18 @@ public class FlatXmlDataSetLoaderTests {
 		this.testContext = manager.accessTestContext();
 	}
 
+	@Test
+	public void shouldLoadMissingColumn() throws Exception {
+		IDataSet dataset = this.loader.loadDataSet(this.testContext.getTestClass(), "test_null_missing_column.xml");
+		assertEquals("test", dataset.getTable("Sample").getValue(1, "name"));
+	}
+	
+	@Test
+	public void shouldLoadNullValue() throws Exception {
+		IDataSet dataset = this.loader.loadDataSet(this.testContext.getTestClass(), "test_null_missing_column.xml");
+		assertEquals(null, dataset.getTable("Sample").getValue(0, "name"));
+	}
+	
 	@Test
 	public void shouldLoadFromRelativeFile() throws Exception {
 		IDataSet dataset = this.loader.loadDataSet(this.testContext.getTestClass(), "test.xml");

--- a/spring-test-dbunit/src/test/resources/com/github/springtestdbunit/dataset/test_null_missing_column.xml
+++ b/spring-test-dbunit/src/test/resources/com/github/springtestdbunit/dataset/test_null_missing_column.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dataset>
+	<Sample id="1"/>
+	<Sample id="2" name="test"/>
+	<Sample id="3" name="[NULL]"/>
+</dataset>


### PR DESCRIPTION
Hi,
It's really nice to have this framework to connect dbunit and spring, I use it a lot in my project. But I also found some issues:
1. there is no way to set one field equals null in xml dataset.
2. when the framework starts loading one table data, only the first row table columns are included, if you add one more column in later rows, it will just (silently) ignore it. 

So I add some changes to fix them:
1. add a ReplacementDataSet to replace token '[NULL]', so it's possible to set filed='[NULL]' in xml dataset.
2. set FlatXmlDataSetBuilder.columnSensing=true to make it also put the table columns added later in table medata.

I also add test methods for above changes, please have a look.

Looking forward to hear your feedback!
