### PR TITLE
Issue 65 - DatabaseAssertionMode.NON_STRICT won't work if the expected data set includes its dtd file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ target
 spring-test-dbunit/src/site/markdown/index.md
 bin
 .DS_Store
+.idea
+*.iml

--- a/spring-test-dbunit/src/main/java/com/github/springtestdbunit/DbUnitRunner.java
+++ b/spring-test-dbunit/src/main/java/com/github/springtestdbunit/DbUnitRunner.java
@@ -19,6 +19,7 @@ package com.github.springtestdbunit;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -28,6 +29,7 @@ import org.dbunit.database.IDatabaseConnection;
 import org.dbunit.dataset.CompositeDataSet;
 import org.dbunit.dataset.IDataSet;
 import org.dbunit.dataset.ITable;
+import org.dbunit.dataset.filter.IColumnFilter;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
@@ -139,6 +141,7 @@ class DbUnitRunner {
 			String query = annotation.query();
 			String table = annotation.table();
 			IDataSet expectedDataSet = loadDataset(testContext, annotation.value(), modifier);
+            List<IColumnFilter> columnFilters = getColumnFilters(annotation);
 			IDatabaseConnection connection = connections.get(annotation.connection());
 			if (expectedDataSet != null) {
 				if (logger.isDebugEnabled()) {
@@ -149,14 +152,14 @@ class DbUnitRunner {
 					Assert.hasLength(table, "The table name must be specified when using a SQL query");
 					ITable expectedTable = expectedDataSet.getTable(table);
 					ITable actualTable = connection.createQueryTable(table, query);
-					assertion.assertEquals(expectedTable, actualTable);
+					assertion.assertEquals(expectedTable, actualTable, columnFilters);
 				} else if (StringUtils.hasLength(table)) {
 					ITable actualTable = connection.createTable(table);
 					ITable expectedTable = expectedDataSet.getTable(table);
-					assertion.assertEquals(expectedTable, actualTable);
+					assertion.assertEquals(expectedTable, actualTable, columnFilters);
 				} else {
 					IDataSet actualDataSet = connection.createDataSet();
-					assertion.assertEquals(expectedDataSet, actualDataSet);
+					assertion.assertEquals(expectedDataSet, actualDataSet, columnFilters);
 				}
 			}
 			if (annotation.override()) {
@@ -165,6 +168,15 @@ class DbUnitRunner {
 			}
 		}
 
+	}
+
+	private List<IColumnFilter> getColumnFilters(ExpectedDatabase annotation) throws IllegalAccessException, InstantiationException {
+		Class<? extends IColumnFilter>[] columnFilterClasses = annotation.columnFilters();
+		List<IColumnFilter> columnFilters = new LinkedList<IColumnFilter>();
+		for(Class<? extends IColumnFilter> columnFilterClass : columnFilterClasses) {
+			columnFilters.add(columnFilterClass.newInstance());
+		}
+		return columnFilters;
 	}
 
 	private DataSetModifier getModifier(DbUnitTestContext testContext, List<ExpectedDatabase> annotations) {

--- a/spring-test-dbunit/src/main/java/com/github/springtestdbunit/annotation/ExpectedDatabase.java
+++ b/spring-test-dbunit/src/main/java/com/github/springtestdbunit/annotation/ExpectedDatabase.java
@@ -29,6 +29,7 @@ import org.dbunit.dataset.IDataSet;
 import com.github.springtestdbunit.DbUnitTestExecutionListener;
 import com.github.springtestdbunit.assertion.DatabaseAssertionMode;
 import com.github.springtestdbunit.dataset.DataSetModifier;
+import org.dbunit.dataset.filter.IColumnFilter;
 
 /**
  * Test annotation that can be used to assert that a database is in given state after tests have run.
@@ -91,4 +92,14 @@ public @interface ExpectedDatabase {
 	 */
 	Class<? extends DataSetModifier>[] modifiers() default {};
 
+	/**
+	 * A set of {@link org.dbunit.dataset.filter.IColumnFilter} that will be applied to column comparison when using
+	 * non strict {@link DatabaseAssertionMode}.
+	 * <p>
+	 * Specify this when you want to use DTD with your expected dataset XML file but want to exclude some columns 
+	 * from comparison.
+	 *
+	 * @return column filters to apply
+	 */
+	Class<? extends IColumnFilter>[] columnFilters() default {};
 }

--- a/spring-test-dbunit/src/main/java/com/github/springtestdbunit/assertion/DatabaseAssertion.java
+++ b/spring-test-dbunit/src/main/java/com/github/springtestdbunit/assertion/DatabaseAssertion.java
@@ -19,6 +19,9 @@ package com.github.springtestdbunit.assertion;
 import org.dbunit.DatabaseUnitException;
 import org.dbunit.dataset.IDataSet;
 import org.dbunit.dataset.ITable;
+import org.dbunit.dataset.filter.IColumnFilter;
+
+import java.util.List;
 
 /**
  * Database assertion strategy interface.
@@ -34,7 +37,7 @@ public interface DatabaseAssertion {
 	 * @param actualDataSet the actual dataset
 	 * @throws DatabaseUnitException if the datasets are not equal
 	 */
-	void assertEquals(IDataSet expectedDataSet, IDataSet actualDataSet) throws DatabaseUnitException;
+	void assertEquals(IDataSet expectedDataSet, IDataSet actualDataSet, List<IColumnFilter> columnFilters) throws DatabaseUnitException;
 
 	/**
 	 * Assert that the specified {@link IDataSet dataSets} are conceptually equal.
@@ -42,6 +45,6 @@ public interface DatabaseAssertion {
 	 * @param actualTable the actual table
 	 * @throws DatabaseUnitException if the tables are not equal
 	 */
-	void assertEquals(ITable expectedTable, ITable actualTable) throws DatabaseUnitException;
+	void assertEquals(ITable expectedTable, ITable actualTable, List<IColumnFilter> columnFilters) throws DatabaseUnitException;
 
 }

--- a/spring-test-dbunit/src/main/java/com/github/springtestdbunit/assertion/DefaultDatabaseAssertion.java
+++ b/spring-test-dbunit/src/main/java/com/github/springtestdbunit/assertion/DefaultDatabaseAssertion.java
@@ -20,6 +20,9 @@ import org.dbunit.Assertion;
 import org.dbunit.DatabaseUnitException;
 import org.dbunit.dataset.IDataSet;
 import org.dbunit.dataset.ITable;
+import org.dbunit.dataset.filter.IColumnFilter;
+
+import java.util.List;
 
 /**
  * Default database assertion strategy which uses DbUnit {@link Assertion#assertEquals(IDataSet, IDataSet)}.
@@ -29,11 +32,11 @@ import org.dbunit.dataset.ITable;
  */
 class DefaultDatabaseAssertion implements DatabaseAssertion {
 
-	public void assertEquals(IDataSet expectedDataSet, IDataSet actualDataSet) throws DatabaseUnitException {
+	public void assertEquals(IDataSet expectedDataSet, IDataSet actualDataSet, List<IColumnFilter> columnFilters) throws DatabaseUnitException {
 		Assertion.assertEquals(expectedDataSet, actualDataSet);
 	}
 
-	public void assertEquals(ITable expectedTable, ITable actualTable) throws DatabaseUnitException {
+	public void assertEquals(ITable expectedTable, ITable actualTable, List<IColumnFilter> columnFilters) throws DatabaseUnitException {
 		Assertion.assertEquals(expectedTable, actualTable);
 	}
 

--- a/spring-test-dbunit/src/main/java/com/github/springtestdbunit/assertion/NonStrictDatabaseAssertion.java
+++ b/spring-test-dbunit/src/main/java/com/github/springtestdbunit/assertion/NonStrictDatabaseAssertion.java
@@ -16,17 +16,12 @@
 
 package com.github.springtestdbunit.assertion;
 
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
 
 import org.dbunit.Assertion;
 import org.dbunit.DatabaseUnitException;
-import org.dbunit.dataset.Column;
-import org.dbunit.dataset.Columns;
-import org.dbunit.dataset.DataSetException;
-import org.dbunit.dataset.IDataSet;
-import org.dbunit.dataset.ITable;
-import org.dbunit.dataset.ITableMetaData;
+import org.dbunit.dataset.*;
+import org.dbunit.dataset.filter.IColumnFilter;
 
 /**
  * Implements non-strict database assertion strategy : compares data sets ignoring all tables and columns which are not
@@ -37,27 +32,51 @@ import org.dbunit.dataset.ITableMetaData;
  */
 class NonStrictDatabaseAssertion implements DatabaseAssertion {
 
-	public void assertEquals(IDataSet expectedDataSet, IDataSet actualDataSet) throws DatabaseUnitException {
+	public void assertEquals(IDataSet expectedDataSet, IDataSet actualDataSet, List<IColumnFilter> columnFilters) throws DatabaseUnitException {
 		for (String tableName : expectedDataSet.getTableNames()) {
 			ITable expectedTable = expectedDataSet.getTable(tableName);
 			ITable actualTable = actualDataSet.getTable(tableName);
-			assertEquals(expectedTable, actualTable);
+			assertEquals(expectedTable, actualTable, columnFilters);
 		}
 	}
 
-	public void assertEquals(ITable expectedTable, ITable actualTable) throws DatabaseUnitException {
-		String[] ignoredColumns = getColumnsToIgnore(expectedTable.getTableMetaData(), actualTable.getTableMetaData());
-		Assertion.assertEqualsIgnoreCols(expectedTable, actualTable, ignoredColumns);
+	public void assertEquals(ITable expectedTable, ITable actualTable, List<IColumnFilter> columnFilters) throws DatabaseUnitException {
+        Set<String> allIgnoredColumns = new LinkedHashSet<String>();
+
+        if (columnFilters.size() == 0) {
+            allIgnoredColumns.addAll(getColumnsToIgnore(expectedTable.getTableMetaData(), actualTable.getTableMetaData()));
+        } else {
+            for(IColumnFilter columnFilter : columnFilters) {
+                FilteredTableMetaData filteredExpectedTableMetaData = new FilteredTableMetaData(expectedTable.getTableMetaData(), columnFilter);
+                allIgnoredColumns.addAll(getColumnsToIgnore(filteredExpectedTableMetaData, actualTable.getTableMetaData()));
+            }
+        }
+
+        Assertion.assertEqualsIgnoreCols(expectedTable, actualTable, allIgnoredColumns.toArray(new String[allIgnoredColumns.size()]));
+
+//        if (parameters.getColumnFilters().size() == 0) {
+//            Set<String> allIgnoredColumns = getColumnsToIgnore(expectedTable.getTableMetaData(), actualTable.getTableMetaData());
+//            Assertion.assertEqualsIgnoreCols(expectedTable, actualTable, allIgnoredColumns.toArray(new String[allIgnoredColumns.size()]));
+//            return;
+//        }
+//
+//        for(IColumnFilter columnFilter : parameters.getColumnFilters()) {
+//            FilteredTableMetaData filteredExpectedTableMetaData = new FilteredTableMetaData(expectedTable.getTableMetaData(), columnFilter);
+//            FilteredTableMetaData filteredActualTableMetaData = new FilteredTableMetaData(actualTable.getTableMetaData(), columnFilter);
+//            ITable filteredExpectedTable = new CompositeTable(filteredExpectedTableMetaData, expectedTable);
+//            ITable filteredActualTable = new CompositeTable(filteredActualTableMetaData, actualTable);
+//            Assertion.assertEquals(filteredExpectedTable, filteredActualTable);
+//        }
 	}
 
-	protected String[] getColumnsToIgnore(ITableMetaData expectedMetaData, ITableMetaData actualMetaData)
+    protected Set<String> getColumnsToIgnore(ITableMetaData expectedMetaData, ITableMetaData actualMetaData)
 			throws DataSetException {
 		Column[] notSpecifiedInExpected = Columns.getColumnDiff(expectedMetaData, actualMetaData).getActual();
-		List<String> result = new LinkedList<String>();
+		Set<String> result = new LinkedHashSet<String>();
 		for (Column column : notSpecifiedInExpected) {
 			result.add(column.getColumnName());
 		}
-		return result.toArray(new String[result.size()]);
+		return result;
 	}
 
 }

--- a/spring-test-dbunit/src/main/java/com/github/springtestdbunit/assertion/NonStrictDatabaseAssertion.java
+++ b/spring-test-dbunit/src/main/java/com/github/springtestdbunit/assertion/NonStrictDatabaseAssertion.java
@@ -53,20 +53,6 @@ class NonStrictDatabaseAssertion implements DatabaseAssertion {
         }
 
         Assertion.assertEqualsIgnoreCols(expectedTable, actualTable, allIgnoredColumns.toArray(new String[allIgnoredColumns.size()]));
-
-//        if (parameters.getColumnFilters().size() == 0) {
-//            Set<String> allIgnoredColumns = getColumnsToIgnore(expectedTable.getTableMetaData(), actualTable.getTableMetaData());
-//            Assertion.assertEqualsIgnoreCols(expectedTable, actualTable, allIgnoredColumns.toArray(new String[allIgnoredColumns.size()]));
-//            return;
-//        }
-//
-//        for(IColumnFilter columnFilter : parameters.getColumnFilters()) {
-//            FilteredTableMetaData filteredExpectedTableMetaData = new FilteredTableMetaData(expectedTable.getTableMetaData(), columnFilter);
-//            FilteredTableMetaData filteredActualTableMetaData = new FilteredTableMetaData(actualTable.getTableMetaData(), columnFilter);
-//            ITable filteredExpectedTable = new CompositeTable(filteredExpectedTableMetaData, expectedTable);
-//            ITable filteredActualTable = new CompositeTable(filteredActualTableMetaData, actualTable);
-//            Assertion.assertEquals(filteredExpectedTable, filteredActualTable);
-//        }
 	}
 
     protected Set<String> getColumnsToIgnore(ITableMetaData expectedMetaData, ITableMetaData actualMetaData)

--- a/spring-test-dbunit/src/main/java/com/github/springtestdbunit/assertion/NonStrictUnorderedDatabaseAssertion.java
+++ b/spring-test-dbunit/src/main/java/com/github/springtestdbunit/assertion/NonStrictUnorderedDatabaseAssertion.java
@@ -20,6 +20,9 @@ import org.dbunit.DatabaseUnitException;
 import org.dbunit.dataset.Column;
 import org.dbunit.dataset.ITable;
 import org.dbunit.dataset.SortedTable;
+import org.dbunit.dataset.filter.IColumnFilter;
+
+import java.util.List;
 
 /**
  * Implements non-strict unordered database assertion strategy : compares data sets ignoring all tables and columns
@@ -33,11 +36,11 @@ import org.dbunit.dataset.SortedTable;
 class NonStrictUnorderedDatabaseAssertion extends NonStrictDatabaseAssertion {
 
 	@Override
-	public void assertEquals(ITable expectedSortedTable, ITable actualSortedTable) throws DatabaseUnitException {
+	public void assertEquals(ITable expectedSortedTable, ITable actualSortedTable, List<IColumnFilter> columnFilters) throws DatabaseUnitException {
 		Column[] expectedColumns = expectedSortedTable.getTableMetaData().getColumns();
 		expectedSortedTable = new SortedTable(expectedSortedTable, expectedColumns);
 		actualSortedTable = new SortedTable(actualSortedTable, expectedColumns);
-		super.assertEquals(expectedSortedTable, actualSortedTable);
+		super.assertEquals(expectedSortedTable, actualSortedTable, columnFilters);
 	}
 
 }

--- a/spring-test-dbunit/src/test/java/com/github/springtestdbunit/expected/ExpectedNonStrictWithDtdTest.java
+++ b/spring-test-dbunit/src/test/java/com/github/springtestdbunit/expected/ExpectedNonStrictWithDtdTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2002-2015 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.springtestdbunit.expected;
+
+import com.github.springtestdbunit.DbUnitTestExecutionListener;
+import com.github.springtestdbunit.annotation.ExpectedDatabase;
+import com.github.springtestdbunit.assertion.DatabaseAssertionMode;
+import com.github.springtestdbunit.entity.EntityAssert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
+import org.springframework.transaction.annotation.Transactional;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration("/META-INF/dbunit-context.xml")
+@TestExecutionListeners({ DependencyInjectionTestExecutionListener.class, DbUnitTestExecutionListener.class })
+@Transactional
+public class ExpectedNonStrictWithDtdTest {
+
+	@Autowired
+	private EntityAssert entityAssert;
+
+	@Test
+	@ExpectedDatabase(value = "/META-INF/db/expected_nonstrict_with_dtd.xml", assertionMode = DatabaseAssertionMode.NON_STRICT)
+	public void shouldNotFailEvenThoughExpectedTableDoesNotSpecifyAllColumns() {
+		this.entityAssert.assertValues("existing1", "existing2");
+	}
+
+}

--- a/spring-test-dbunit/src/test/java/com/github/springtestdbunit/expected/ExpectedNonStrictWithDtdTest.java
+++ b/spring-test-dbunit/src/test/java/com/github/springtestdbunit/expected/ExpectedNonStrictWithDtdTest.java
@@ -20,6 +20,8 @@ import com.github.springtestdbunit.DbUnitTestExecutionListener;
 import com.github.springtestdbunit.annotation.ExpectedDatabase;
 import com.github.springtestdbunit.assertion.DatabaseAssertionMode;
 import com.github.springtestdbunit.entity.EntityAssert;
+import org.dbunit.dataset.Column;
+import org.dbunit.dataset.filter.IColumnFilter;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,14 +36,23 @@ import org.springframework.transaction.annotation.Transactional;
 @TestExecutionListeners({ DependencyInjectionTestExecutionListener.class, DbUnitTestExecutionListener.class })
 @Transactional
 public class ExpectedNonStrictWithDtdTest {
-
-	@Autowired
-	private EntityAssert entityAssert;
+    @Autowired
+    private EntityAssert entityAssert;
 
 	@Test
-	@ExpectedDatabase(value = "/META-INF/db/expected_nonstrict_with_dtd.xml", assertionMode = DatabaseAssertionMode.NON_STRICT)
+	@ExpectedDatabase(value = "/META-INF/db/expected_nonstrict_with_dtd.xml",
+			assertionMode = DatabaseAssertionMode.NON_STRICT
+			, columnFilters = { SampleEntityIdExclusionFilter.class }
+	)
 	public void shouldNotFailEvenThoughExpectedTableDoesNotSpecifyAllColumns() {
 		this.entityAssert.assertValues("existing1", "existing2");
 	}
 
+	public static class SampleEntityIdExclusionFilter implements IColumnFilter {
+		public boolean accept(String tableName, Column column) {
+			boolean isExcluded = tableName.equals("SampleEntity") && column.getColumnName().equals("id");
+			return !isExcluded;
+		}
+	}
 }
+

--- a/spring-test-dbunit/src/test/resources/META-INF/db/expected_nonstrict_with_dtd.xml
+++ b/spring-test-dbunit/src/test/resources/META-INF/db/expected_nonstrict_with_dtd.xml
@@ -7,6 +7,6 @@
                 value CDATA #REQUIRED>
         ]>
 <dataset>
-	<SampleEntity value="existing1" />
-	<SampleEntity value="existing2" />
+	<SampleEntity id="this_is_actually_1_but_will_not_be_compared_due_to_specified_IColumnFilter" value="existing1" />
+	<SampleEntity id="this_is_actually_2_but_will_not_be_compared_due_to_specified_IColumnFilter" value="existing2" />
 </dataset>

--- a/spring-test-dbunit/src/test/resources/META-INF/db/expected_nonstrict_with_dtd.xml
+++ b/spring-test-dbunit/src/test/resources/META-INF/db/expected_nonstrict_with_dtd.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE dataset [
+        <!ELEMENT dataset (SampleEntity)*>
+        <!ELEMENT SampleEntity (#PCDATA)>
+        <!ATTLIST SampleEntity
+                id CDATA #REQUIRED
+                value CDATA #REQUIRED>
+        ]>
+<dataset>
+	<SampleEntity value="existing1" />
+	<SampleEntity value="existing2" />
+</dataset>


### PR DESCRIPTION
This is a proposal for ISSUE-65 - failing to use non-strict DatabaseAssertionModes when XML includes DTD.

I added ExpectedDatabase.columnFilters() attribute which enables one to specify set of dbunit IColumnFilter-s to be used to explicitly control which columns get ignored when using any of non-strict DatabaseAssertionModes.

To ignore columns based on provided IColumnFilters I used DbUnit column filter feature described here: http://dbunit.sourceforge.net/faq.html#columnfilter.

Usage example can be seen in ExpectedNonStrictWithDtdTest.

Please let me know what you think, any suggestions are most welcome.