### PR TITLE
Allow to leave dataset value unspecified in order to clean all tables

### DIFF
--- a/spring-test-dbunit/src/main/java/com/github/springtestdbunit/DbUnitRunner.java
+++ b/spring-test-dbunit/src/main/java/com/github/springtestdbunit/DbUnitRunner.java
@@ -202,6 +202,9 @@ class DbUnitRunner {
 		for (String dataSetLocation : annotation.getValue()) {
 			datasets.add(loadDataset(testContext, dataSetLocation, DataSetModifier.NONE));
 		}
+		if (datasets.isEmpty()) {
+			datasets.add(testContext.getConnections().get(annotation.getConnection()).createDataSet());
+		}
 		return datasets;
 	}
 

--- a/spring-test-dbunit/src/main/java/com/github/springtestdbunit/annotation/DatabaseSetup.java
+++ b/spring-test-dbunit/src/main/java/com/github/springtestdbunit/annotation/DatabaseSetup.java
@@ -66,6 +66,6 @@ public @interface DatabaseSetup {
 	 * @return The dataset locations
 	 * @see DbUnitConfiguration#dataSetLoader()
 	 */
-	String[] value();
+	String[] value() default {};
 
 }

--- a/spring-test-dbunit/src/main/java/com/github/springtestdbunit/annotation/DatabaseTearDown.java
+++ b/spring-test-dbunit/src/main/java/com/github/springtestdbunit/annotation/DatabaseTearDown.java
@@ -62,6 +62,6 @@ public @interface DatabaseTearDown {
 	 * @return The dataset locations
 	 * @see DbUnitConfiguration#dataSetLoader()
 	 */
-	String[] value();
+	String[] value() default {};
 
 }

--- a/spring-test-dbunit/src/test/java/com/github/springtestdbunit/setup/DeleteAllSetupOnMethodTest.java
+++ b/spring-test-dbunit/src/test/java/com/github/springtestdbunit/setup/DeleteAllSetupOnMethodTest.java
@@ -45,4 +45,10 @@ public class DeleteAllSetupOnMethodTest {
 		this.entityAssert.assertValues();
 	}
 
+	@Test
+	@DatabaseSetup(type = DatabaseOperation.DELETE_ALL)
+	public void testAllTables() throws Exception {
+		this.entityAssert.assertValues();
+	}
+
 }

--- a/spring-test-dbunit/src/test/java/com/github/springtestdbunit/setup/TruncateSetupOnMethodTest.java
+++ b/spring-test-dbunit/src/test/java/com/github/springtestdbunit/setup/TruncateSetupOnMethodTest.java
@@ -45,4 +45,10 @@ public class TruncateSetupOnMethodTest {
 		this.entityAssert.assertValues();
 	}
 
+	@Test
+	@DatabaseSetup(type = DatabaseOperation.TRUNCATE_TABLE)
+	public void testAllTables() throws Exception {
+		this.entityAssert.assertValues();
+	}
+
 }


### PR DESCRIPTION
I was one of the authors of the DBUnit integration in Resthub framework. It was possible to truncate/delete all tables using annotations.
Since this part of the framework is no longer maintained in Resthub, I wanted to contribute this feature. I find it very useful to fully clear the database before some tests.
Let me know if you find this feature interesting.