### PR TITLE
Making spring-test-dbunit extensible by making DbUnitRunner and rel...

### DIFF
--- a/spring-test-dbunit/src/main/java/com/github/springtestdbunit/DatabaseConnections.java
+++ b/spring-test-dbunit/src/main/java/com/github/springtestdbunit/DatabaseConnections.java
@@ -27,7 +27,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Phillip Webb
  */
-class DatabaseConnections {
+public class DatabaseConnections {
 
 	private final String[] names;
 

--- a/spring-test-dbunit/src/main/java/com/github/springtestdbunit/DbUnitRunner.java
+++ b/spring-test-dbunit/src/main/java/com/github/springtestdbunit/DbUnitRunner.java
@@ -52,7 +52,7 @@ import com.github.springtestdbunit.dataset.DataSetModifier;
  * @author Sunitha Rajarathnam
  * @author Oleksii Lomako
  */
-class DbUnitRunner {
+public class DbUnitRunner {
 
 	private static final Log logger = LogFactory.getLog(DbUnitTestExecutionListener.class);
 

--- a/spring-test-dbunit/src/main/java/com/github/springtestdbunit/DbUnitTestContext.java
+++ b/spring-test-dbunit/src/main/java/com/github/springtestdbunit/DbUnitTestContext.java
@@ -29,7 +29,7 @@ import com.github.springtestdbunit.operation.DatabaseOperationLookup;
  *
  * @author Phillip Webb
  */
-interface DbUnitTestContext {
+public interface DbUnitTestContext {
 
 	/**
 	 * Returns the {@link IDatabaseConnection} that should be used when performing database setup and teardown.


### PR DESCRIPTION
Make DbUnitRunner reusable outside of spring by making DbUnitRunner and related classes public.

DbUnitRunner.java
DatabaseConnections.java
DbUnitTestContext.java

By making it public, DbUnitRunner can be used  in custom extension of JUnit's BlockJUnit4ClassRunner, as shown below,

```java
public class DBUnitJUnitRunner extends BlockJUnit4ClassRunner {
	private RPDbUnitTestContext dbUnitTestContext;
	private DbUnitRunner runner;

	public RPApplicationAwareJUnitRunner(Class<?> klass) throws InitializationError {
		super(klass);
		dbUnitTestContext = new RPDbUnitTestContext(klass);
		runner = new DbUnitRunner();
	}

	@Override
	protected Statement withBeforeClasses(Statement statement) {
		Statement junitBeforeClasses = super.withBeforeClasses(statement);
		return new BeforeClassStatement(junitBeforeClasses);
	}

	@Override
	protected Statement withAfterClasses(Statement statement) {
		Statement junitAfterClasses = super.withAfterClasses(statement);
		return new AfterClassStatement(junitAfterClasses);
	}

	@Override
	protected Object createTest() throws Exception {
		Object testInstance = super.createTest();
		return testInstance;
	}

	@Override
	protected Statement withBefores(FrameworkMethod frameworkMethod, Object testInstance, Statement statement) {
		Statement junitBefores = super.withBefores(frameworkMethod, testInstance, statement);
		dbUnitTestContext.setTestMethod(frameworkMethod.getMethod());
		dbUnitTestContext.setTestInstance(testInstance);
		return new BeforeMethodStatement(junitBefores);
	}

	@Override
	protected Statement withAfters(FrameworkMethod frameworkMethod, Object testInstance, Statement statement) {
		Statement junitAfters = super.withAfters(frameworkMethod, testInstance, statement);
		return new AfterMethodStatement(junitAfters);
	}

	private class BeforeClassStatement extends Statement {
		private final Statement wrapped;

		BeforeClassStatement(Statement statement) {
			this.wrapped = statement;

		}

		@Override
		public void evaluate() throws Throwable {

			dbUnitTestContext.setDatabaseConnection(new DatabaseConnection(getConnection()));
			dbUnitTestContext.setDataSetLoader(FlatXmlDataSetLoader.class.newInstance());
			dbUnitTestContext.setDatabaseOperationLookup(DefaultDatabaseOperationLookup.class.newInstance());

			wrapped.evaluate();
		}
	}

	private class AfterClassStatement extends Statement {
		private final Statement wrapped;

		public AfterClassStatement(Statement statement) {
			this.wrapped = statement;
 

		@Override
		public void evaluate() throws Throwable {
			wrapped.evaluate();
		}
	}

	private class BeforeMethodStatement extends Statement {
		private final Statement wrapped;

		BeforeMethodStatement(Statement statement) {
			this.wrapped = statement;

		}

		@Override
		public void evaluate() throws Throwable {
			runner.beforeTestMethod(dbUnitTestContext);
			wrapped.evaluate();
		}
	}

	private class AfterMethodStatement extends Statement {
		private final Statement wrapped;

		public AfterMethodStatement(Statement statement) {
			this.wrapped = statement;

		}

		@Override
		public void evaluate() throws Throwable {
			wrapped.evaluate();
			runner.afterTestMethod(dbUnitTestContext);

		}
	}
}
```