### PR TITLE
Upgraded dbunit to 2.5.1 and added support for allowEmptyFields config

### DIFF
--- a/spring-test-dbunit/pom.xml
+++ b/spring-test-dbunit/pom.xml
@@ -255,7 +255,7 @@
 		<dependency>
 			<groupId>org.dbunit</groupId>
 			<artifactId>dbunit</artifactId>
-			<version>2.4.9</version>
+			<version>2.5.1</version>
 			<type>jar</type>
 			<scope>provided</scope>
 			<exclusions>

--- a/spring-test-dbunit/pom.xml
+++ b/spring-test-dbunit/pom.xml
@@ -35,7 +35,7 @@
 	</prerequisites>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<java.version>1.5</java.version>
+		<java.version>1.8</java.version>
 		<spring.version>4.1.4.RELEASE</spring.version>
 	</properties>
 	<developers>
@@ -91,6 +91,7 @@
 				<configuration>
 					<compilerVersion>${java.version}</compilerVersion>
 					<source>${java.version}</source>
+					<target>${java.version}</target>
 					<testSource>1.8</testSource>
 					<testTarget>1.8</testTarget>
 				</configuration>

--- a/spring-test-dbunit/src/main/java/com/github/springtestdbunit/bean/DatabaseConfigBean.java
+++ b/spring-test-dbunit/src/main/java/com/github/springtestdbunit/bean/DatabaseConfigBean.java
@@ -302,6 +302,23 @@ public class DatabaseConfigBean {
 				skipOracleRecyclebinTables);
 	}
 
+    /**
+     * Gets the allow empty fields database config feature.
+     * @return the allow empty fields
+     * @see DatabaseConfig#FEATURE_ALLOW_EMPTY_FIELDS
+     */
+    public Boolean getAllowEmptyFields() {
+        return (Boolean) getProperty("allowEmptyFields", DatabaseConfig.FEATURE_ALLOW_EMPTY_FIELDS);
+    }
+
+    /**
+     * Sets the allow empty fields database config feature.
+     * @param allowEmptyFields allow empty fields
+     * @see DatabaseConfig#FEATURE_ALLOW_EMPTY_FIELDS
+     */
+    public void setAllowEmptyFields(Boolean allowEmptyFields) {
+        setProperty("allowEmptyFields", DatabaseConfig.FEATURE_ALLOW_EMPTY_FIELDS, allowEmptyFields);
+    }
 	/**
 	 * Get a property from the underlying database config.
 	 * @param propertyName The name of the attribute

--- a/spring-test-dbunit/src/test/java/com/github/springtestdbunit/bean/DatabaseConfigBeanTests.java
+++ b/spring-test-dbunit/src/test/java/com/github/springtestdbunit/bean/DatabaseConfigBeanTests.java
@@ -145,6 +145,11 @@ public class DatabaseConfigBeanTests {
 		doTest("skipOracleRecyclebinTables", DatabaseConfig.FEATURE_SKIP_ORACLE_RECYCLEBIN_TABLES, Boolean.FALSE);
 	}
 
+    @Test
+    public void testAllowEmptyFields() {
+        doTest("allowEmptyFields", DatabaseConfig.FEATURE_ALLOW_EMPTY_FIELDS, Boolean.TRUE);
+    }
+
 	private void doTest(String propertyName, String databaseConfigProperty, Object newValue) {
 		Object initialValue = this.configBeanWrapper.getPropertyValue(propertyName);
 		Object expectedInitialValue = this.defaultConfig.getProperty(databaseConfigProperty);


### PR DESCRIPTION
There was a new config parameter added to allow empty field values which has a default value of false. This config parameter could not be added through the DatabaseConfigBean, so added getter and setter for this DatabaseConfig.FEATURE_ALLOW_EMPTY_FIELDS.

see http://sourceforge.net/p/dbunit/bugs/363/
and http://sourceforge.net/p/dbunit/code.git/ci/2a461dd1853abaf8af4b7f66cc84214c60206b1f/

Not sure if I followed conventions. Please review.