### PR TITLE
Multi data source test fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ target
 spring-test-dbunit/src/site/markdown/index.md
 bin
 .DS_Store
+*.iml
+.idea

--- a/spring-test-dbunit/src/test/java/com/github/springtestdbunit/DbUnitTestExecutionListenerPrepareTests.java
+++ b/spring-test-dbunit/src/test/java/com/github/springtestdbunit/DbUnitTestExecutionListenerPrepareTests.java
@@ -78,7 +78,7 @@ public class DbUnitTestExecutionListenerPrepareTests {
 		ExtendedTestContextManager testContextManager = new ExtendedTestContextManager(NoDbUnitConfiguration.class);
 		testContextManager.prepareTestInstance();
 		DatabaseConnections connections = (DatabaseConnections) testContextManager.getTestContextAttribute(
-			DbUnitTestExecutionListener.CONNECTION_ATTRIBUTE);
+				DbUnitTestExecutionListener.CONNECTION_ATTRIBUTE);
 		assertSame(this.databaseConnection, connections.get(databaseConnectionBeanName));
 		assertEquals(FlatXmlDataSetLoader.class,
 				testContextManager.getTestContextAttribute(DbUnitTestExecutionListener.DATA_SET_LOADER_ATTRIBUTE)
@@ -112,12 +112,13 @@ public class DbUnitTestExecutionListenerPrepareTests {
 
 	@Test
 	public void shouldConvertDatasetDatabaseConnection() throws Exception {
-		addBean("dataSource", this.dataSource);
+		String dataSourceBeanName = "dataSource";
+		addBean(dataSourceBeanName, this.dataSource);
 		ExtendedTestContextManager testContextManager = new ExtendedTestContextManager(NoDbUnitConfiguration.class);
 		testContextManager.prepareTestInstance();
 		DatabaseConnections connections = (DatabaseConnections) testContextManager
 				.getTestContextAttribute(DbUnitTestExecutionListener.CONNECTION_ATTRIBUTE);
-		assertEquals(DatabaseDataSourceConnection.class, connections.get("dataSource").getClass());
+		assertEquals(DatabaseDataSourceConnection.class, connections.get(dataSourceBeanName).getClass());
 	}
 
 	@Test
@@ -150,7 +151,7 @@ public class DbUnitTestExecutionListenerPrepareTests {
 		testContextManager.prepareTestInstance();
 		verify(this.applicationContext).getBean(customDatabaseConnectionBeanName);
 		DatabaseConnections connections = (DatabaseConnections) testContextManager.getTestContextAttribute(
-			DbUnitTestExecutionListener.CONNECTION_ATTRIBUTE);
+				DbUnitTestExecutionListener.CONNECTION_ATTRIBUTE);
 		assertSame(this.databaseConnection, connections.get(customDatabaseConnectionBeanName));
 		assertEquals(CustomDataSetLoader.class,
 				testContextManager.getTestContextAttribute(DbUnitTestExecutionListener.DATA_SET_LOADER_ATTRIBUTE)

--- a/spring-test-dbunit/src/test/java/com/github/springtestdbunit/DbUnitTestExecutionListenerPrepareTests.java
+++ b/spring-test-dbunit/src/test/java/com/github/springtestdbunit/DbUnitTestExecutionListenerPrepareTests.java
@@ -73,11 +73,13 @@ public class DbUnitTestExecutionListenerPrepareTests {
 
 	@Test
 	public void shouldUseSensibleDefaultsOnClassWithNoDbUnitConfiguration() throws Exception {
-		addBean("dbUnitDatabaseConnection", this.databaseConnection);
+		String databaseConnectionBeanName = "dbUnitDatabaseConnection";
+		addBean(databaseConnectionBeanName, this.databaseConnection);
 		ExtendedTestContextManager testContextManager = new ExtendedTestContextManager(NoDbUnitConfiguration.class);
 		testContextManager.prepareTestInstance();
-		assertSame(this.databaseConnection,
-				testContextManager.getTestContextAttribute(DbUnitTestExecutionListener.CONNECTION_ATTRIBUTE));
+		DatabaseConnections connections = (DatabaseConnections) testContextManager.getTestContextAttribute(
+			DbUnitTestExecutionListener.CONNECTION_ATTRIBUTE);
+		assertSame(this.databaseConnection, connections.get(databaseConnectionBeanName));
 		assertEquals(FlatXmlDataSetLoader.class,
 				testContextManager.getTestContextAttribute(DbUnitTestExecutionListener.DATA_SET_LOADER_ATTRIBUTE)
 						.getClass());
@@ -113,9 +115,9 @@ public class DbUnitTestExecutionListenerPrepareTests {
 		addBean("dataSource", this.dataSource);
 		ExtendedTestContextManager testContextManager = new ExtendedTestContextManager(NoDbUnitConfiguration.class);
 		testContextManager.prepareTestInstance();
-		Object connection = testContextManager
+		DatabaseConnections connections = (DatabaseConnections) testContextManager
 				.getTestContextAttribute(DbUnitTestExecutionListener.CONNECTION_ATTRIBUTE);
-		assertEquals(DatabaseDataSourceConnection.class, connection.getClass());
+		assertEquals(DatabaseDataSourceConnection.class, connections.get("dataSource").getClass());
 	}
 
 	@Test
@@ -142,12 +144,14 @@ public class DbUnitTestExecutionListenerPrepareTests {
 
 	@Test
 	public void shouldSupportAllDbUnitConfigurationAttributes() throws Exception {
-		addBean("customBean", this.databaseConnection);
+		String customDatabaseConnectionBeanName = "customBean";
+		addBean(customDatabaseConnectionBeanName, this.databaseConnection);
 		ExtendedTestContextManager testContextManager = new ExtendedTestContextManager(CustomConfiguration.class);
 		testContextManager.prepareTestInstance();
-		verify(this.applicationContext).getBean("customBean");
-		assertSame(this.databaseConnection,
-				testContextManager.getTestContextAttribute(DbUnitTestExecutionListener.CONNECTION_ATTRIBUTE));
+		verify(this.applicationContext).getBean(customDatabaseConnectionBeanName);
+		DatabaseConnections connections = (DatabaseConnections) testContextManager.getTestContextAttribute(
+			DbUnitTestExecutionListener.CONNECTION_ATTRIBUTE);
+		assertSame(this.databaseConnection, connections.get(customDatabaseConnectionBeanName));
 		assertEquals(CustomDataSetLoader.class,
 				testContextManager.getTestContextAttribute(DbUnitTestExecutionListener.DATA_SET_LOADER_ATTRIBUTE)
 						.getClass());


### PR DESCRIPTION
Hi.

I tried to build project from master but 3 tests failed because previous changes with multi data source support broke some asserts. In tests concrete classes like DatabaseDataSourceConnection were compared with DatabaseConnections one which is holder for objects of DatabaseDataSourceConnection classes.