### PR TITLE
Update the snapshot version to 1.3.1-SNAPSHOT from 1.3.0-SNAPSHOT

### DIFF
--- a/spring-test-dbunit-sample/pom.xml
+++ b/spring-test-dbunit-sample/pom.xml
@@ -75,7 +75,7 @@
 		<dependency>
 			<groupId>com.github.springtestdbunit</groupId>
 			<artifactId>spring-test-dbunit</artifactId>
-			<version>1.3.0-SNAPSHOT</version>
+			<version>1.3.1-SNAPSHOT</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
spring-test-dbunit-sample is not building due to the incorrect SNAPSHOT version
