### PR TITLE
Allow database assertion to be defined as a bean

### DIFF
--- a/spring-test-dbunit/src/main/java/com/github/springtestdbunit/DbUnitRunner.java
+++ b/spring-test-dbunit/src/main/java/com/github/springtestdbunit/DbUnitRunner.java
@@ -138,7 +138,13 @@ public class DbUnitRunner {
 			if (logger.isDebugEnabled()) {
 				logger.debug("Veriftying @DatabaseTest expectation using " + annotation.value());
 			}
-			DatabaseAssertion assertion = annotation.assertionMode().getDatabaseAssertion();
+
+			DatabaseAssertion assertion;
+			if (StringUtils.hasLength(annotation.assertionBean())) {
+				assertion = testContext.getDatabaseAssertion(annotation.assertionBean());
+			} else {
+				assertion = annotation.assertionMode().getDatabaseAssertion();
+			}
 			List<IColumnFilter> columnFilters = getColumnFilters(annotation);
 			if (StringUtils.hasLength(query)) {
 				Assert.hasLength(table, "The table name must be specified when using a SQL query");

--- a/spring-test-dbunit/src/main/java/com/github/springtestdbunit/DbUnitTestContext.java
+++ b/spring-test-dbunit/src/main/java/com/github/springtestdbunit/DbUnitTestContext.java
@@ -18,6 +18,7 @@ package com.github.springtestdbunit;
 
 import java.lang.reflect.Method;
 
+import com.github.springtestdbunit.assertion.DatabaseAssertion;
 import org.dbunit.database.IDatabaseConnection;
 import org.dbunit.dataset.IDataSet;
 
@@ -48,6 +49,13 @@ public interface DbUnitTestContext {
 	 * @return the database operation lookup
 	 */
 	DatabaseOperationLookup getDatbaseOperationLookup();
+
+	/**
+	 * Returns the {@link DatabaseAssertion} implemented by the bean with the given name.
+	 * @param databaseAssertionBeanName  name of the database assertion bean
+	 * @return  database assertion
+	 */
+	DatabaseAssertion getDatabaseAssertion(String databaseAssertionBeanName);
 
 	/**
 	 * Returns the class that is under test.

--- a/spring-test-dbunit/src/main/java/com/github/springtestdbunit/DbUnitTestExecutionListener.java
+++ b/spring-test-dbunit/src/main/java/com/github/springtestdbunit/DbUnitTestExecutionListener.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 
 import javax.sql.DataSource;
 
+import com.github.springtestdbunit.assertion.DatabaseAssertion;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.dbunit.database.IDatabaseConnection;
@@ -234,6 +235,10 @@ public class DbUnitTestExecutionListener extends AbstractTestExecutionListener {
 
 		public DatabaseOperationLookup getDatbaseOperationLookup() {
 			return (DatabaseOperationLookup) getAttribute(DATABASE_OPERATION_LOOKUP_ATTRIBUTE);
+		}
+
+		public DatabaseAssertion getDatabaseAssertion(String databaseAssertionBeanName) {
+			return testContext.getApplicationContext().getBean(databaseAssertionBeanName, DatabaseAssertion.class);
 		}
 
 		public Class<?> getTestClass() {

--- a/spring-test-dbunit/src/main/java/com/github/springtestdbunit/annotation/ExpectedDatabase.java
+++ b/spring-test-dbunit/src/main/java/com/github/springtestdbunit/annotation/ExpectedDatabase.java
@@ -24,6 +24,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import com.github.springtestdbunit.assertion.DatabaseAssertion;
 import org.dbunit.dataset.IDataSet;
 import org.dbunit.dataset.filter.IColumnFilter;
 
@@ -65,6 +66,14 @@ public @interface ExpectedDatabase {
 	 * @return Database assertion mode to use
 	 */
 	DatabaseAssertionMode assertionMode() default DatabaseAssertionMode.DEFAULT;
+
+	/**
+	 * The name of the database assertion bean to use for comparing datasets.
+	 * This bean must implement the {@link DatabaseAssertion} interface.
+	 * If defined, this supersedes the {@link ExpectedDatabase#assertionMode()} element.
+	 * @return Database assertion bean to use
+	 */
+	String assertionBean() default "";
 
 	/**
 	 * Optional table name that can be used to limit the comparison to a specific table.


### PR DESCRIPTION
Problem to solve:
I would like to implement a custom logic for validating actual vs expected datasets.
Spring-dbunit uses DatabaseAssertion objects for such validations.
However, at present, the ExpectedDatabase annotation only accepts DatabaseAssertionMode. But DatabaseAssertionMode is an enum, which means that I cannot extend it in my project.

Proposed solution:
Similar to how you have "dataSetLoader" and "dataSetLoaderBean" elements in DbUnitConfiguration, I've added an "assertionBean" element to ExpectedDatabase. So now I can define any database assertion I like as a bean and refer to it in the annotation.
## Example:

```
@Bean
public DatabaseAssertion dbAssertion() {
    return new CustomDatabaseAssertion();
}
```

---

```
@Test
@ExpectedDatabase(value = "classpath:/datasets/Expected.xml",
        assertionBean = "dbAssertion")
public void test() throws Exception {
    ....
```

---
