### PR TITLE
Add Meta-Annotation support

### DIFF
--- a/spring-test-dbunit/src/main/java/com/github/springtestdbunit/DbUnitTestExecutionListener.java
+++ b/spring-test-dbunit/src/main/java/com/github/springtestdbunit/DbUnitTestExecutionListener.java
@@ -26,6 +26,7 @@ import org.apache.commons.logging.LogFactory;
 import org.dbunit.database.IDatabaseConnection;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.Conventions;
+import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.support.AbstractTestExecutionListener;
 import org.springframework.test.context.transaction.TransactionalTestExecutionListener;
@@ -96,7 +97,7 @@ public class DbUnitTestExecutionListener extends AbstractTestExecutionListener {
 		Class<? extends DataSetLoader> dataSetLoaderClass = FlatXmlDataSetLoader.class;
 		Class<? extends DatabaseOperationLookup> databaseOperationLookupClass = DefaultDatabaseOperationLookup.class;
 
-		DbUnitConfiguration configuration = testContext.getTestClass().getAnnotation(DbUnitConfiguration.class);
+		DbUnitConfiguration configuration = AnnotationUtils.getAnnotation(testContext.getTestClass(), DbUnitConfiguration.class);
 		if (configuration != null) {
 			if (logger.isDebugEnabled()) {
 				logger.debug("Using @DbUnitConfiguration configuration");

--- a/spring-test-dbunit/src/test/java/com/github/springtestdbunit/DbUnitTestExecutionListenerPrepareTest.java
+++ b/spring-test-dbunit/src/test/java/com/github/springtestdbunit/DbUnitTestExecutionListenerPrepareTest.java
@@ -21,6 +21,11 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
 import javax.sql.DataSource;
 
 import org.dbunit.database.DatabaseDataSourceConnection;
@@ -177,6 +182,16 @@ public class DbUnitTestExecutionListenerPrepareTest {
 				.getTestContextAttribute(DbUnitTestExecutionListener.DATA_SET_LOADER_ATTRIBUTE).getClass());
 	}
 
+	@Test
+	public void shouldSupportMetaAnnotations() throws Exception {
+		addBean("customBean", this.databaseConnection);
+		ExtendedTestContextManager testContextManager = new ExtendedTestContextManager(MetaAnnotatedConfiguration.class);
+		testContextManager.prepareTestInstance();
+		DatabaseConnections databaseConnections = (DatabaseConnections) testContextManager
+				.getTestContextAttribute(DbUnitTestExecutionListener.CONNECTION_ATTRIBUTE);
+		assertSame(this.databaseConnection, databaseConnections.get("customBean"));
+	}
+
 	private static class LocalApplicationContextLoader implements ContextLoader {
 		public String[] processLocations(Class<?> clazz, String... locations) {
 			return new String[] {};
@@ -226,6 +241,20 @@ public class DbUnitTestExecutionListenerPrepareTest {
 	@TestExecutionListeners(DbUnitTestExecutionListener.class)
 	@DbUnitConfiguration(dataSetLoader = AbstractCustomDataSetLoader.class)
 	private static class NonCreatableDataSetLoader {
+
+	}
+
+	@ContextConfiguration(loader = LocalApplicationContextLoader.class)
+	@TestExecutionListeners(DbUnitTestExecutionListener.class)
+	@MetaAnnotation
+	private static class MetaAnnotatedConfiguration {
+
+	}
+
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target(ElementType.TYPE)
+	@DbUnitConfiguration(databaseConnection = "customBean")
+	private @interface MetaAnnotation {
 
 	}
 


### PR DESCRIPTION
Modern Spring code heavily uses and promotes the use of meta-annotations (see http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#beans-meta-annotations).

To be able to write idiomatic Sprint testing code, Spring DBUnit should support meta-annotations for its own annotations.

This pull request adds support for `@DbUnitConfiguration` as a meta-annotation. This should be the annotation that people would want to use most frequently as a meta-annotation. Support for the other annotations can be added later as well.

This change is fully backwards-compatible with existing code, since it only changes Annotation searching of `@DbUnitConfiguration` from _present_ on a class to _present_ and _meta-present_ on the class (see Spring `AnnotationUtils` Javadocs for definition of the terms).
