### PR TITLE
Fix for @DatabaseSetup annotation on superclasses

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.github.springtestdbunit.parent</groupId>
 	<artifactId>spring-test-dbunit-parent</artifactId>
-	<version>1.3.0-SNAPSHOT</version>
+	<version>1.3.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>Spring Test DBUnit Parent</name>
 	<modules>

--- a/spring-test-dbunit-sample/pom.xml
+++ b/spring-test-dbunit-sample/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.github.springtestdbunit.sample</groupId>
 	<artifactId>spring-test-dbunit-sample</artifactId>
-	<version>1.3.0-SNAPSHOT</version>
+	<version>1.3.1-SNAPSHOT</version>
 	<name>Spring Test DBUnit Sample</name>
 	<properties>
 		<spring.version>4.2.5.RELEASE</spring.version>
@@ -75,7 +75,7 @@
 		<dependency>
 			<groupId>com.github.springtestdbunit</groupId>
 			<artifactId>spring-test-dbunit</artifactId>
-			<version>1.3.0-SNAPSHOT</version>
+			<version>1.3.1-SNAPSHOT</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-test-dbunit/src/main/java/com/github/springtestdbunit/DbUnitRunner.java
+++ b/spring-test-dbunit/src/main/java/com/github/springtestdbunit/DbUnitRunner.java
@@ -17,7 +17,7 @@
 package com.github.springtestdbunit;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Method;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -280,15 +280,23 @@ public class DbUnitRunner {
 		private final List<T> allAnnotations;
 
 		public Annotations(DbUnitTestContext context, Class<? extends Annotation> container, Class<T> annotation) {
-			this.classAnnotations = getAnnotations(context.getTestClass(), container, annotation);
-			this.methodAnnotations = getAnnotations(context.getTestMethod(), container, annotation);
+			this.classAnnotations = getClassAnnotations(context.getTestClass(), container, annotation);
+			this.methodAnnotations = getMethodAnnotations(context.getTestMethod(), container, annotation);
 			List<T> allAnnotations = new ArrayList<T>(this.classAnnotations.size() + this.methodAnnotations.size());
 			allAnnotations.addAll(this.classAnnotations);
 			allAnnotations.addAll(this.methodAnnotations);
 			this.allAnnotations = Collections.unmodifiableList(allAnnotations);
 		}
 
-		private List<T> getAnnotations(AnnotatedElement element, Class<? extends Annotation> container,
+		private List<T> getClassAnnotations(Class<?> element, Class<? extends Annotation> container,
+				Class<T> annotation) {
+			List<T> annotations = new ArrayList<T>();
+			addAnnotationToList(annotations, AnnotationUtils.findAnnotation(element, annotation));
+			addRepeatableAnnotationsToList(annotations, AnnotationUtils.findAnnotation(element, container));
+			return Collections.unmodifiableList(annotations);
+		}
+
+		private List<T> getMethodAnnotations(Method element, Class<? extends Annotation> container,
 				Class<T> annotation) {
 			List<T> annotations = new ArrayList<T>();
 			addAnnotationToList(annotations, AnnotationUtils.findAnnotation(element, annotation));

--- a/spring-test-dbunit/src/test/java/com/github/springtestdbunit/setup/ChildClassUsingParentClassDatabaseSetupTest.java
+++ b/spring-test-dbunit/src/test/java/com/github/springtestdbunit/setup/ChildClassUsingParentClassDatabaseSetupTest.java
@@ -1,0 +1,18 @@
+package com.github.springtestdbunit.setup;
+
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.github.springtestdbunit.entity.EntityAssert;
+
+public class ChildClassUsingParentClassDatabaseSetupTest extends ParentClassContainingDatabaseSetup {
+
+    @Autowired
+    private EntityAssert entityAssert;
+
+    @Test
+    public void test() throws Exception {
+        this.entityAssert.assertValues("fromDbUnit");
+    }
+
+}

--- a/spring-test-dbunit/src/test/java/com/github/springtestdbunit/setup/ParentClassContainingDatabaseSetup.java
+++ b/spring-test-dbunit/src/test/java/com/github/springtestdbunit/setup/ParentClassContainingDatabaseSetup.java
@@ -1,0 +1,21 @@
+package com.github.springtestdbunit.setup;
+
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.github.springtestdbunit.TransactionDbUnitTestExecutionListener;
+import com.github.springtestdbunit.annotation.DatabaseOperation;
+import com.github.springtestdbunit.annotation.DatabaseSetup;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration("/META-INF/dbunit-context.xml")
+@TestExecutionListeners({ DependencyInjectionTestExecutionListener.class,
+        TransactionDbUnitTestExecutionListener.class })
+@DatabaseSetup(type = DatabaseOperation.CLEAN_INSERT, value = "/META-INF/db/insert.xml")
+@Transactional
+public abstract class ParentClassContainingDatabaseSetup {
+}


### PR DESCRIPTION
Hi,

This pull request should fix issue #103. The class `DbUnitRunner` will now use the overloaded `findAnnotation` method on the `org.springframework.core.annotation.AnnotationUtils` class in Spring Core that takes a `Class<?>` as an argument opposed to `AnnotatedElement.` The latter will only look for the annotation on the given class while the other methods tries to look on it's parent classes/interfaces if the annotation is not present on the given class itself.

This reintroduces the behaviour from older version of spring-test-dbunit.